### PR TITLE
feat(notifier): Template-to-Label Mapping Service (Story 2.2.2)

### DIFF
--- a/src/notifier/services/label_service.py
+++ b/src/notifier/services/label_service.py
@@ -1,0 +1,473 @@
+"""
+Template-to-Label Mapping Service for Intelligent Template Triaging.
+
+This module provides functionality to map detected template types to
+GitHub labels for automatic issue triaging.
+
+Story 2.2.2: Template-to-Label Mapping Service
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic_settings import BaseSettings
+
+from src.models import TaskType
+
+logger = logging.getLogger(__name__)
+
+
+# Default label mappings from TaskType to GitHub labels
+DEFAULT_LABEL_MAPPINGS: dict[TaskType, list[str]] = {
+    TaskType.PLAN: ["agent:queued", "orchestration:dispatch"],
+    TaskType.BUG: ["agent:queued", "bug"],
+    TaskType.FEATURE: ["agent:queued", "enhancement"],
+    TaskType.ENHANCEMENT: ["agent:queued", "enhancement"],
+    TaskType.IMPLEMENT: ["agent:queued"],
+    TaskType.GENERIC: ["agent:queued"],
+}
+
+
+class LabelMappingSettings(BaseSettings):
+    """
+    Settings for label mapping configuration.
+
+    Supports environment-based customization of label mappings.
+
+    Environment Variables:
+        LABEL_MAPPINGS: JSON string with custom label mappings
+                       Format: {"PLAN": ["label1", "label2"], ...}
+        ENABLE_AUTO_TRIAGE: Enable/disable automatic triaging (default: true)
+    """
+
+    # JSON string for custom label mappings
+    label_mappings: str = ""
+
+    # Feature flag for auto-triage
+    enable_auto_triage: bool = True
+
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "case_sensitive": False,
+        "extra": "ignore",
+    }
+
+
+@dataclass
+class TriageResult:
+    """
+    Result of triaging an issue.
+
+    Attributes:
+        detected_type: The detected TaskType from parsing.
+        labels_to_apply: List of GitHub labels to apply.
+        already_present: Labels that were already on the issue.
+        skipped: Whether triaging was skipped (already has agent labels).
+        reason: Reason for the triage decision.
+    """
+
+    detected_type: TaskType
+    labels_to_apply: list[str] = field(default_factory=list)
+    already_present: list[str] = field(default_factory=list)
+    skipped: bool = False
+    reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for serialization."""
+        return {
+            "detected_type": self.detected_type.value,
+            "labels_to_apply": self.labels_to_apply,
+            "already_present": self.already_present,
+            "skipped": self.skipped,
+            "reason": self.reason,
+        }
+
+
+class TemplateLabelMapper:
+    """
+    Maps detected template types to GitHub labels.
+
+    This class provides configurable mappings from TaskType enum values
+    to lists of GitHub label names. It supports:
+    - Default mappings for all template types
+    - Custom mappings via environment variables
+    - Runtime configuration updates
+    - Checking if triaging should be skipped
+
+    Example:
+        ```python
+        mapper = TemplateLabelMapper()
+        result = mapper.triage_issue(
+            detected_type=TaskType.BUG,
+            existing_labels=["priority:high"]
+        )
+        print(result.labels_to_apply)  # ["agent:queued", "bug"]
+        ```
+    """
+
+    # Prefixes that indicate an agent label is already present
+    AGENT_LABEL_PREFIXES = ["agent:", "orchestration:", "implementation:"]
+
+    def __init__(
+        self,
+        custom_mappings: dict[TaskType, list[str]] | None = None,
+        settings: LabelMappingSettings | None = None,
+    ):
+        """
+        Initialize the Template Label Mapper.
+
+        Args:
+            custom_mappings: Optional custom label mappings to override defaults.
+            settings: Optional settings instance. If not provided, creates default.
+        """
+        self._settings = settings or LabelMappingSettings()
+        self._mappings = self._build_mappings(custom_mappings)
+
+        logger.info(
+            f"TemplateLabelMapper initialized with {len(self._mappings)} mappings, "
+            f"auto_triage={'enabled' if self._settings.enable_auto_triage else 'disabled'}"
+        )
+
+    def _build_mappings(
+        self,
+        custom_mappings: dict[TaskType, list[str]] | None = None,
+    ) -> dict[TaskType, list[str]]:
+        """
+        Build the label mappings from defaults, env vars, and custom mappings.
+
+        Priority (highest to lowest):
+        1. Custom mappings passed to constructor
+        2. Environment variable LABEL_MAPPINGS
+        3. Default mappings
+
+        Args:
+            custom_mappings: Custom mappings from constructor.
+
+        Returns:
+            Complete mapping dictionary.
+        """
+        # Start with defaults
+        mappings = dict(DEFAULT_LABEL_MAPPINGS)
+
+        # Apply environment variable mappings
+        if self._settings.label_mappings:
+            try:
+                env_mappings = json.loads(self._settings.label_mappings)
+                for key, labels in env_mappings.items():
+                    try:
+                        task_type = TaskType(key.upper())
+                        mappings[task_type] = labels
+                        logger.debug(
+                            f"Applied env mapping: {task_type.value} -> {labels}"
+                        )
+                    except ValueError:
+                        logger.warning(
+                            f"Unknown TaskType in env mapping: {key}, skipping"
+                        )
+            except json.JSONDecodeError as e:
+                logger.warning(f"Invalid LABEL_MAPPINGS JSON: {e}, using defaults")
+
+        # Apply custom mappings (highest priority)
+        if custom_mappings:
+            for task_type, labels in custom_mappings.items():
+                mappings[task_type] = labels
+                logger.debug(f"Applied custom mapping: {task_type.value} -> {labels}")
+
+        return mappings
+
+    @property
+    def is_auto_triage_enabled(self) -> bool:
+        """Check if automatic triaging is enabled."""
+        return self._settings.enable_auto_triage
+
+    def get_labels_for_type(self, task_type: TaskType) -> list[str]:
+        """
+        Get the labels to apply for a given task type.
+
+        Args:
+            task_type: The detected TaskType.
+
+        Returns:
+            List of label names to apply.
+        """
+        return self._mappings.get(task_type, [])
+
+    def has_agent_labels(self, labels: list[str]) -> bool:
+        """
+        Check if the issue already has agent-related labels.
+
+        Args:
+            labels: List of existing label names.
+
+        Returns:
+            True if any agent label prefix is found.
+        """
+        for label in labels:
+            label_lower = label.lower()
+            for prefix in self.AGENT_LABEL_PREFIXES:
+                if label_lower.startswith(prefix):
+                    return True
+        return False
+
+    def filter_existing_labels(
+        self,
+        labels_to_apply: list[str],
+        existing_labels: list[str],
+    ) -> tuple[list[str], list[str]]:
+        """
+        Filter out labels that already exist on the issue.
+
+        Args:
+            labels_to_apply: Labels we want to apply.
+            existing_labels: Labels already on the issue.
+
+        Returns:
+            Tuple of (labels_to_add, already_present).
+        """
+        existing_lower = {label.lower() for label in existing_labels}
+        to_add = []
+        already_present = []
+
+        for label in labels_to_apply:
+            if label.lower() in existing_lower:
+                already_present.append(label)
+            else:
+                to_add.append(label)
+
+        return to_add, already_present
+
+    def triage_issue(
+        self,
+        detected_type: TaskType,
+        existing_labels: list[str] | None = None,
+    ) -> TriageResult:
+        """
+        Determine the labels to apply for an issue based on detected type.
+
+        This method handles:
+        1. Checking if auto-triage is enabled
+        2. Checking if issue already has agent labels
+        3. Getting the appropriate labels for the type
+        4. Filtering out labels that already exist
+
+        Args:
+            detected_type: The detected TaskType from parsing.
+            existing_labels: Labels already on the issue.
+
+        Returns:
+            TriageResult with labels to apply and metadata.
+        """
+        existing_labels = existing_labels or []
+
+        # Check if auto-triage is enabled
+        if not self._settings.enable_auto_triage:
+            return TriageResult(
+                detected_type=detected_type,
+                labels_to_apply=[],
+                skipped=True,
+                reason="Auto-triage is disabled by configuration",
+            )
+
+        # Check if issue already has agent labels
+        if self.has_agent_labels(existing_labels):
+            return TriageResult(
+                detected_type=detected_type,
+                labels_to_apply=[],
+                already_present=existing_labels,
+                skipped=True,
+                reason="Issue already has agent-related labels",
+            )
+
+        # Get labels for the detected type
+        labels_to_apply = self.get_labels_for_type(detected_type)
+
+        # Filter out labels that already exist
+        labels_to_add, already_present = self.filter_existing_labels(
+            labels_to_apply, existing_labels
+        )
+
+        reason = f"Detected type: {detected_type.value}"
+        if already_present:
+            reason += f", {len(already_present)} labels already present"
+
+        return TriageResult(
+            detected_type=detected_type,
+            labels_to_apply=labels_to_add,
+            already_present=already_present,
+            skipped=False,
+            reason=reason,
+        )
+
+    def update_mappings(self, new_mappings: dict[TaskType, list[str]]) -> None:
+        """
+        Update the label mappings at runtime.
+
+        Args:
+            new_mappings: New mappings to apply (merged with existing).
+        """
+        self._mappings.update(new_mappings)
+        logger.info(f"Updated label mappings: {list(new_mappings.keys())}")
+
+    def get_all_mappings(self) -> dict[TaskType, list[str]]:
+        """
+        Get all current label mappings.
+
+        Returns:
+            Copy of the current mappings dictionary.
+        """
+        return dict(self._mappings)
+
+
+class TriageService:
+    """
+    High-level service for issue triaging.
+
+    Combines the Issue Body Parser and Template Label Mapper
+    to provide end-to-end triaging functionality.
+
+    Example:
+        ```python
+        from src.notifier.parsers.issue_parser import IssueBodyParser
+        from src.notifier.services.label_service import TriageService
+
+        parser = IssueBodyParser()
+        service = TriageService(parser=parser)
+
+        result = service.triage(
+            body="# [Bug] Something is broken",
+            labels=["priority:high"],
+            title="Fix this bug",
+        )
+        print(result.labels_to_apply)  # ["agent:queued", "bug"]
+        ```
+    """
+
+    def __init__(
+        self,
+        parser: Any = None,  # IssueBodyParser type hint avoided to prevent circular import
+        mapper: TemplateLabelMapper | None = None,
+    ):
+        """
+        Initialize the Triage Service.
+
+        Args:
+            parser: Optional IssueBodyParser instance. If not provided,
+                   a default parser will be created lazily.
+            mapper: Optional TemplateLabelMapper instance. If not provided,
+                   a default mapper will be created.
+        """
+        self._parser = parser
+        self._mapper = mapper or TemplateLabelMapper()
+
+    @property
+    def parser(self):
+        """Get or create the parser instance."""
+        if self._parser is None:
+            from src.notifier.parsers.issue_parser import IssueBodyParser
+
+            self._parser = IssueBodyParser()
+        return self._parser
+
+    @property
+    def mapper(self) -> TemplateLabelMapper:
+        """Get the mapper instance."""
+        return self._mapper
+
+    def triage(
+        self,
+        body: str | None,
+        labels: list[str] | None = None,
+        title: str | None = None,
+    ) -> TriageResult:
+        """
+        Perform full triaging on an issue.
+
+        This method:
+        1. Parses the issue body to detect the template type
+        2. Maps the detected type to appropriate labels
+        3. Returns a TriageResult with labels to apply
+
+        Args:
+            body: The issue body text.
+            labels: Existing labels on the issue.
+            title: Optional issue title for enhanced detection.
+
+        Returns:
+            TriageResult with triaging decision and labels.
+        """
+        # Parse the issue body with context
+        parse_result = self.parser.parse_with_fallback(body, labels, title)
+
+        # Map to labels
+        triage_result = self._mapper.triage_issue(
+            detected_type=parse_result.detected_type,
+            existing_labels=labels,
+        )
+
+        # Add parse metadata to reason
+        if parse_result.matched_pattern:
+            triage_result.reason += f" (matched: {parse_result.matched_pattern})"
+
+        logger.info(
+            f"Triage result: type={triage_result.detected_type.value}, "
+            f"labels={triage_result.labels_to_apply}, "
+            f"skipped={triage_result.skipped}"
+        )
+
+        return triage_result
+
+    def is_enabled(self) -> bool:
+        """Check if auto-triage is enabled."""
+        return self._mapper.is_auto_triage_enabled
+
+
+# Module-level convenience instances
+_default_mapper: TemplateLabelMapper | None = None
+_default_service: TriageService | None = None
+
+
+def get_default_mapper() -> TemplateLabelMapper:
+    """Get or create the default label mapper instance."""
+    global _default_mapper
+    if _default_mapper is None:
+        _default_mapper = TemplateLabelMapper()
+    return _default_mapper
+
+
+def get_default_service() -> TriageService:
+    """Get or create the default triage service instance."""
+    global _default_service
+    if _default_service is None:
+        _default_service = TriageService()
+    return _default_service
+
+
+def triage_issue(
+    body: str | None,
+    labels: list[str] | None = None,
+    title: str | None = None,
+) -> TriageResult:
+    """
+    Convenience function for quick issue triaging.
+
+    Uses default parser and mapper instances.
+
+    Args:
+        body: The issue body text.
+        labels: Existing labels on the issue.
+        title: Optional issue title.
+
+    Returns:
+        TriageResult with triaging decision and labels.
+
+    Example:
+        >>> result = triage_issue("# [Bug] Something broken", [], "Fix bug")
+        >>> result.labels_to_apply
+        ['agent:queued', 'bug']
+    """
+    return get_default_service().triage(body, labels, title)

--- a/src/notifier/services/label_service.py
+++ b/src/notifier/services/label_service.py
@@ -9,11 +9,10 @@ Story 2.2.2: Template-to-Label Mapping Service
 
 import json
 import logging
-import os
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings
 
 from src.models import TaskType
@@ -363,14 +362,18 @@ class TriageService:
         """
         self._parser = parser
         self._mapper = mapper or TemplateLabelMapper()
+        self._parser_lock = threading.Lock()
 
     @property
     def parser(self):
-        """Get or create the parser instance."""
+        """Get or create the parser instance (thread-safe)."""
         if self._parser is None:
-            from src.notifier.parsers.issue_parser import IssueBodyParser
+            with self._parser_lock:
+                # Double-checked locking pattern
+                if self._parser is None:
+                    from src.notifier.parsers.issue_parser import IssueBodyParser
 
-            self._parser = IssueBodyParser()
+                    self._parser = IssueBodyParser()
         return self._parser
 
     @property
@@ -429,21 +432,29 @@ class TriageService:
 # Module-level convenience instances
 _default_mapper: TemplateLabelMapper | None = None
 _default_service: TriageService | None = None
+_mapper_lock = threading.Lock()
+_service_lock = threading.Lock()
 
 
 def get_default_mapper() -> TemplateLabelMapper:
-    """Get or create the default label mapper instance."""
+    """Get or create the default label mapper instance (thread-safe)."""
     global _default_mapper
     if _default_mapper is None:
-        _default_mapper = TemplateLabelMapper()
+        with _mapper_lock:
+            # Double-checked locking pattern
+            if _default_mapper is None:
+                _default_mapper = TemplateLabelMapper()
     return _default_mapper
 
 
 def get_default_service() -> TriageService:
-    """Get or create the default triage service instance."""
+    """Get or create the default triage service instance (thread-safe)."""
     global _default_service
     if _default_service is None:
-        _default_service = TriageService()
+        with _service_lock:
+            # Double-checked locking pattern
+            if _default_service is None:
+                _default_service = TriageService()
     return _default_service
 
 

--- a/tests/unit/test_label_service.py
+++ b/tests/unit/test_label_service.py
@@ -1,0 +1,568 @@
+"""
+Unit tests for Template-to-Label Mapping Service.
+
+Story 2.2.2: Template-to-Label Mapping Service
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.models import TaskType
+from src.notifier.services.label_service import (
+    DEFAULT_LABEL_MAPPINGS,
+    LabelMappingSettings,
+    TemplateLabelMapper,
+    TriageResult,
+    TriageService,
+    get_default_mapper,
+    get_default_service,
+    triage_issue,
+)
+
+
+class TestLabelMappingSettings:
+    """Tests for LabelMappingSettings."""
+
+    def test_default_settings(self):
+        """Test default settings values."""
+        settings = LabelMappingSettings()
+        assert settings.label_mappings == ""
+        assert settings.enable_auto_triage is True
+
+    def test_custom_settings(self):
+        """Test custom settings via constructor."""
+        settings = LabelMappingSettings(
+            label_mappings='{"PLAN": ["custom:plan"]}',
+            enable_auto_triage=False,
+        )
+        assert settings.label_mappings == '{"PLAN": ["custom:plan"]}'
+        assert settings.enable_auto_triage is False
+
+
+class TestTriageResult:
+    """Tests for TriageResult dataclass."""
+
+    def test_triage_result_defaults(self):
+        """Test TriageResult with minimal arguments."""
+        result = TriageResult(detected_type=TaskType.BUG)
+        assert result.detected_type == TaskType.BUG
+        assert result.labels_to_apply == []
+        assert result.already_present == []
+        assert result.skipped is False
+        assert result.reason == ""
+
+    def test_triage_result_full(self):
+        """Test TriageResult with all arguments."""
+        result = TriageResult(
+            detected_type=TaskType.PLAN,
+            labels_to_apply=["agent:queued", "orchestration:dispatch"],
+            already_present=["priority:high"],
+            skipped=False,
+            reason="Detected type: PLAN",
+        )
+        assert result.detected_type == TaskType.PLAN
+        assert result.labels_to_apply == ["agent:queued", "orchestration:dispatch"]
+        assert result.already_present == ["priority:high"]
+        assert result.skipped is False
+        assert result.reason == "Detected type: PLAN"
+
+    def test_triage_result_to_dict(self):
+        """Test TriageResult serialization."""
+        result = TriageResult(
+            detected_type=TaskType.BUG,
+            labels_to_apply=["agent:queued", "bug"],
+            skipped=False,
+            reason="Detected type: BUG",
+        )
+        data = result.to_dict()
+        assert data["detected_type"] == "BUG"
+        assert data["labels_to_apply"] == ["agent:queued", "bug"]
+        assert data["skipped"] is False
+        assert data["reason"] == "Detected type: BUG"
+
+
+class TestTemplateLabelMapper:
+    """Tests for TemplateLabelMapper class."""
+
+    @pytest.fixture
+    def mapper(self):
+        """Create a mapper instance for testing."""
+        return TemplateLabelMapper()
+
+    # ========================================
+    # Default Mappings Tests
+    # ========================================
+
+    def test_default_mappings_exist(self):
+        """Test that default mappings are defined."""
+        assert TaskType.PLAN in DEFAULT_LABEL_MAPPINGS
+        assert TaskType.BUG in DEFAULT_LABEL_MAPPINGS
+        assert TaskType.FEATURE in DEFAULT_LABEL_MAPPINGS
+        assert TaskType.ENHANCEMENT in DEFAULT_LABEL_MAPPINGS
+        assert TaskType.IMPLEMENT in DEFAULT_LABEL_MAPPINGS
+        assert TaskType.GENERIC in DEFAULT_LABEL_MAPPINGS
+
+    def test_default_plan_mapping(self, mapper):
+        """Test default PLAN mapping."""
+        labels = mapper.get_labels_for_type(TaskType.PLAN)
+        assert "agent:queued" in labels
+        assert "orchestration:dispatch" in labels
+
+    def test_default_bug_mapping(self, mapper):
+        """Test default BUG mapping."""
+        labels = mapper.get_labels_for_type(TaskType.BUG)
+        assert "agent:queued" in labels
+        assert "bug" in labels
+
+    def test_default_feature_mapping(self, mapper):
+        """Test default FEATURE mapping."""
+        labels = mapper.get_labels_for_type(TaskType.FEATURE)
+        assert "agent:queued" in labels
+        assert "enhancement" in labels
+
+    def test_default_enhancement_mapping(self, mapper):
+        """Test default ENHANCEMENT mapping."""
+        labels = mapper.get_labels_for_type(TaskType.ENHANCEMENT)
+        assert "agent:queued" in labels
+        assert "enhancement" in labels
+
+    def test_default_implement_mapping(self, mapper):
+        """Test default IMPLEMENT mapping."""
+        labels = mapper.get_labels_for_type(TaskType.IMPLEMENT)
+        assert "agent:queued" in labels
+
+    def test_default_generic_mapping(self, mapper):
+        """Test default GENERIC mapping."""
+        labels = mapper.get_labels_for_type(TaskType.GENERIC)
+        assert "agent:queued" in labels
+
+    # ========================================
+    # Custom Mappings Tests
+    # ========================================
+
+    def test_custom_mappings_constructor(self):
+        """Test custom mappings via constructor."""
+        custom = {
+            TaskType.BUG: ["custom:bug", "priority:critical"],
+        }
+        mapper = TemplateLabelMapper(custom_mappings=custom)
+        labels = mapper.get_labels_for_type(TaskType.BUG)
+        assert labels == ["custom:bug", "priority:critical"]
+
+    def test_custom_mappings_override_defaults(self):
+        """Test that custom mappings override defaults."""
+        custom = {
+            TaskType.PLAN: ["custom:plan"],
+        }
+        mapper = TemplateLabelMapper(custom_mappings=custom)
+        labels = mapper.get_labels_for_type(TaskType.PLAN)
+        assert labels == ["custom:plan"]
+        assert "agent:queued" not in labels
+
+    def test_custom_mappings_preserves_other_defaults(self):
+        """Test that custom mappings don't affect other types."""
+        custom = {
+            TaskType.BUG: ["custom:bug"],
+        }
+        mapper = TemplateLabelMapper(custom_mappings=custom)
+
+        # BUG should use custom mapping
+        bug_labels = mapper.get_labels_for_type(TaskType.BUG)
+        assert bug_labels == ["custom:bug"]
+
+        # FEATURE should still use default
+        feature_labels = mapper.get_labels_for_type(TaskType.FEATURE)
+        assert "agent:queued" in feature_labels
+        assert "enhancement" in feature_labels
+
+    def test_environment_variable_mappings(self):
+        """Test custom mappings via environment variable."""
+        env_value = '{"FEATURE": ["custom:feature", "needs-review"]}'
+        with patch.dict(os.environ, {"LABEL_MAPPINGS": env_value}):
+            # Need to create new instance to pick up env var
+            mapper = TemplateLabelMapper()
+            labels = mapper.get_labels_for_type(TaskType.FEATURE)
+            assert "custom:feature" in labels
+            assert "needs-review" in labels
+
+    def test_invalid_env_json_uses_defaults(self):
+        """Test that invalid env JSON falls back to defaults."""
+        with patch.dict(os.environ, {"LABEL_MAPPINGS": "not valid json"}):
+            mapper = TemplateLabelMapper()
+            # Should still have default mappings
+            labels = mapper.get_labels_for_type(TaskType.BUG)
+            assert "agent:queued" in labels
+
+    # ========================================
+    # Agent Label Detection Tests
+    # ========================================
+
+    def test_has_agent_labels_agent_prefix(self, mapper):
+        """Test detection of agent: prefixed labels."""
+        assert mapper.has_agent_labels(["agent:queued"]) is True
+        assert mapper.has_agent_labels(["agent:in-progress"]) is True
+        assert mapper.has_agent_labels(["agent:success"]) is True
+
+    def test_has_agent_labels_orchestration_prefix(self, mapper):
+        """Test detection of orchestration: prefixed labels."""
+        assert mapper.has_agent_labels(["orchestration:dispatch"]) is True
+        assert mapper.has_agent_labels(["orchestration:plan"]) is True
+
+    def test_has_agent_labels_implementation_prefix(self, mapper):
+        """Test detection of implementation: prefixed labels."""
+        assert mapper.has_agent_labels(["implementation:ready"]) is True
+
+    def test_has_agent_labels_no_match(self, mapper):
+        """Test that non-agent labels are not detected."""
+        assert mapper.has_agent_labels(["bug", "priority:high"]) is False
+        assert mapper.has_agent_labels([]) is False
+        assert mapper.has_agent_labels(["enhancement"]) is False
+
+    def test_has_agent_labels_case_insensitive(self, mapper):
+        """Test case-insensitive label detection."""
+        assert mapper.has_agent_labels(["AGENT:QUEUED"]) is True
+        assert mapper.has_agent_labels(["Agent:In-Progress"]) is True
+
+    # ========================================
+    # Label Filtering Tests
+    # ========================================
+
+    def test_filter_existing_labels_none_exist(self, mapper):
+        """Test filtering when no labels exist."""
+        to_apply = ["agent:queued", "bug"]
+        existing = []
+        to_add, already = mapper.filter_existing_labels(to_apply, existing)
+        assert to_add == ["agent:queued", "bug"]
+        assert already == []
+
+    def test_filter_existing_labels_some_exist(self, mapper):
+        """Test filtering when some labels exist."""
+        to_apply = ["agent:queued", "bug"]
+        existing = ["bug", "priority:high"]
+        to_add, already = mapper.filter_existing_labels(to_apply, existing)
+        assert to_add == ["agent:queued"]
+        assert already == ["bug"]
+
+    def test_filter_existing_labels_all_exist(self, mapper):
+        """Test filtering when all labels exist."""
+        to_apply = ["agent:queued", "bug"]
+        existing = ["agent:queued", "bug", "priority:high"]
+        to_add, already = mapper.filter_existing_labels(to_apply, existing)
+        assert to_add == []
+        assert set(already) == {"agent:queued", "bug"}
+
+    def test_filter_existing_labels_case_insensitive(self, mapper):
+        """Test case-insensitive label filtering."""
+        to_apply = ["agent:queued", "BUG"]
+        existing = ["Agent:Queued", "bug"]
+        to_add, already = mapper.filter_existing_labels(to_apply, existing)
+        assert to_add == []
+        assert len(already) == 2
+
+    # ========================================
+    # Triage Tests
+    # ========================================
+
+    def test_triage_issue_basic(self, mapper):
+        """Test basic triaging."""
+        result = mapper.triage_issue(TaskType.BUG, existing_labels=[])
+        assert result.detected_type == TaskType.BUG
+        assert "agent:queued" in result.labels_to_apply
+        assert "bug" in result.labels_to_apply
+        assert result.skipped is False
+
+    def test_triage_issue_skips_existing_agent_labels(self, mapper):
+        """Test that triaging skips issues with existing agent labels."""
+        result = mapper.triage_issue(
+            TaskType.BUG,
+            existing_labels=["agent:in-progress"],
+        )
+        assert result.skipped is True
+        assert result.labels_to_apply == []
+        assert "already has agent-related labels" in result.reason
+
+    def test_triage_issue_filters_existing_labels(self, mapper):
+        """Test that existing labels are filtered out."""
+        result = mapper.triage_issue(
+            TaskType.BUG,
+            existing_labels=["bug", "priority:high"],
+        )
+        assert result.skipped is False
+        # "bug" should be filtered out, "agent:queued" should be added
+        assert result.labels_to_apply == ["agent:queued"]
+        assert "bug" in result.already_present
+
+    def test_triage_issue_disabled_auto_triage(self):
+        """Test that triaging is skipped when auto-triage is disabled."""
+        with patch.dict(os.environ, {"ENABLE_AUTO_TRIAGE": "false"}):
+            mapper = TemplateLabelMapper()
+            result = mapper.triage_issue(TaskType.BUG, existing_labels=[])
+            assert result.skipped is True
+            assert result.labels_to_apply == []
+            assert "disabled" in result.reason.lower()
+
+    def test_triage_issue_each_type(self, mapper):
+        """Test triaging for each TaskType."""
+        types_and_expected = [
+            (TaskType.PLAN, ["agent:queued", "orchestration:dispatch"]),
+            (TaskType.BUG, ["agent:queued", "bug"]),
+            (TaskType.FEATURE, ["agent:queued", "enhancement"]),
+            (TaskType.ENHANCEMENT, ["agent:queued", "enhancement"]),
+            (TaskType.IMPLEMENT, ["agent:queued"]),
+            (TaskType.GENERIC, ["agent:queued"]),
+        ]
+
+        for task_type, expected_labels in types_and_expected:
+            result = mapper.triage_issue(task_type, existing_labels=[])
+            assert result.labels_to_apply == expected_labels, f"Failed for {task_type}"
+
+    # ========================================
+    # Runtime Updates Tests
+    # ========================================
+
+    def test_update_mappings(self, mapper):
+        """Test runtime mapping updates."""
+        new_mappings = {
+            TaskType.BUG: ["updated:bug"],
+        }
+        mapper.update_mappings(new_mappings)
+        labels = mapper.get_labels_for_type(TaskType.BUG)
+        assert labels == ["updated:bug"]
+
+    def test_get_all_mappings(self, mapper):
+        """Test getting all mappings."""
+        all_mappings = mapper.get_all_mappings()
+        assert TaskType.BUG in all_mappings
+        assert TaskType.FEATURE in all_mappings
+        # Verify it's a copy
+        all_mappings[TaskType.BUG] = ["modified"]
+        assert mapper.get_labels_for_type(TaskType.BUG) != ["modified"]
+
+    def test_is_auto_triage_enabled(self, mapper):
+        """Test auto-triage enabled check."""
+        assert mapper.is_auto_triage_enabled is True
+
+
+class TestTriageService:
+    """Tests for TriageService class."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a service instance for testing."""
+        return TriageService()
+
+    @pytest.fixture
+    def mock_parser(self):
+        """Create a mock parser."""
+        parser = MagicMock()
+        return parser
+
+    @pytest.fixture
+    def mock_mapper(self):
+        """Create a mock mapper."""
+        mapper = MagicMock()
+        mapper.is_auto_triage_enabled = True
+        return mapper
+
+    def test_service_initialization_default(self, service):
+        """Test default service initialization."""
+        assert service.parser is not None
+        assert service.mapper is not None
+
+    def test_service_initialization_custom(self, mock_parser, mock_mapper):
+        """Test custom service initialization."""
+        service = TriageService(parser=mock_parser, mapper=mock_mapper)
+        assert service.parser is mock_parser
+        assert service.mapper is mock_mapper
+
+    def test_triage_basic(self, service):
+        """Test basic triaging through service."""
+        result = service.triage(
+            body="# [Bug] Something is broken",
+            labels=[],
+            title="Fix this bug",
+        )
+        assert result.detected_type == TaskType.BUG
+        assert "agent:queued" in result.labels_to_apply
+        assert "bug" in result.labels_to_apply
+
+    def test_triage_plan_issue(self, service):
+        """Test triaging a plan issue."""
+        result = service.triage(
+            body="# [Application Plan]\n\nThis is a plan...",
+            labels=[],
+            title="Epic: New Feature",
+        )
+        assert result.detected_type == TaskType.PLAN
+        assert "agent:queued" in result.labels_to_apply
+        assert "orchestration:dispatch" in result.labels_to_apply
+
+    def test_triage_feature_issue(self, service):
+        """Test triaging a feature request."""
+        result = service.triage(
+            body="# [Feature] Add new button",
+            labels=[],
+            title="New feature request",
+        )
+        assert result.detected_type == TaskType.FEATURE
+        assert "agent:queued" in result.labels_to_apply
+        assert "enhancement" in result.labels_to_apply
+
+    def test_triage_generic_issue(self, service):
+        """Test triaging a generic issue."""
+        result = service.triage(
+            body="Just a question about the API",
+            labels=[],
+            title="Question about API",
+        )
+        assert result.detected_type == TaskType.GENERIC
+        assert "agent:queued" in result.labels_to_apply
+
+    def test_triage_skips_existing_agent_labels(self, service):
+        """Test that service skips issues with existing agent labels."""
+        result = service.triage(
+            body="# [Bug] Something is broken",
+            labels=["agent:in-progress"],
+            title="Fix this bug",
+        )
+        assert result.skipped is True
+        assert result.labels_to_apply == []
+
+    def test_triage_with_label_fallback(self, service):
+        """Test that labels are used for detection fallback."""
+        # Body doesn't indicate type, but label does
+        result = service.triage(
+            body="Some generic text",
+            labels=["bug"],
+            title="Something",
+        )
+        # Label should influence detection
+        assert result.detected_type == TaskType.BUG
+
+    def test_triage_with_title_fallback(self, service):
+        """Test that title is used for detection fallback."""
+        # Body doesn't indicate type, but title does
+        result = service.triage(
+            body="Some generic text",
+            labels=[],
+            title="[Bug] App crashes",
+        )
+        assert result.detected_type == TaskType.BUG
+
+    def test_is_enabled(self, service):
+        """Test checking if service is enabled."""
+        assert service.is_enabled() is True
+
+
+class TestModuleFunctions:
+    """Tests for module-level convenience functions."""
+
+    def test_get_default_mapper(self):
+        """Test get_default_mapper returns singleton."""
+        mapper1 = get_default_mapper()
+        mapper2 = get_default_mapper()
+        assert mapper1 is mapper2
+
+    def test_get_default_service(self):
+        """Test get_default_service returns singleton."""
+        service1 = get_default_service()
+        service2 = get_default_service()
+        assert service1 is service2
+
+    def test_triage_issue_function(self):
+        """Test triage_issue convenience function."""
+        result = triage_issue(
+            body="# [Bug] Something is broken",
+            labels=[],
+            title="Fix bug",
+        )
+        assert result.detected_type == TaskType.BUG
+        assert "agent:queued" in result.labels_to_apply
+
+    def test_triage_issue_function_empty(self):
+        """Test triage_issue with empty input."""
+        result = triage_issue(None, None, None)
+        assert result.detected_type == TaskType.GENERIC
+
+
+class TestIntegration:
+    """Integration tests for the complete triaging flow."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a service instance for testing."""
+        return TriageService()
+
+    def test_full_triage_flow_bug(self, service):
+        """Test complete triage flow for a bug report."""
+        body = """# [Bug] Webhook signature validation fails
+
+## Description
+When I send a webhook from GitHub, the signature validation fails.
+
+## Steps to Reproduce
+1. Configure webhook in GitHub
+2. Send a test event
+3. Check logs for 401 error
+
+## Expected Behavior
+Signature should validate successfully.
+"""
+        result = service.triage(body=body, labels=[], title="Webhook fails")
+
+        assert result.detected_type == TaskType.BUG
+        assert "agent:queued" in result.labels_to_apply
+        assert "bug" in result.labels_to_apply
+        assert result.skipped is False
+
+    def test_full_triage_flow_plan(self, service):
+        """Test complete triage flow for a plan/epic."""
+        body = """## Overview
+
+This epic implements **Intelligent Template Triaging** for the system.
+
+## Goals
+1. Automated Label Application
+2. Template Pattern Recognition
+
+## Epic Stories
+### Story 1: Parser Module
+### Story 2: Label Service
+"""
+        result = service.triage(
+            body=body, labels=["epic"], title="Epic: Template Triaging"
+        )
+
+        assert result.detected_type == TaskType.PLAN
+        assert "agent:queued" in result.labels_to_apply
+        assert "orchestration:dispatch" in result.labels_to_apply
+
+    def test_full_triage_flow_feature(self, service):
+        """Test complete triage flow for a feature request."""
+        body = """# [Feature Request] Add Slack notifications
+
+## User Story
+As a developer, I want to be notified via Slack when tasks complete.
+
+## Acceptance Criteria
+- [ ] Slack webhook integration
+- [ ] Configurable settings
+"""
+        result = service.triage(body=body, labels=[], title="Add Slack notifications")
+
+        assert result.detected_type == TaskType.FEATURE
+        assert "agent:queued" in result.labels_to_apply
+        assert "enhancement" in result.labels_to_apply
+
+    def test_full_triage_flow_already_triaged(self, service):
+        """Test that already-triaged issues are skipped."""
+        body = "# [Bug] Something is broken"
+        result = service.triage(
+            body=body,
+            labels=["agent:in-progress", "bug"],
+            title="Fix bug",
+        )
+
+        assert result.skipped is True
+        assert result.labels_to_apply == []


### PR DESCRIPTION
## Summary

Implements Story 2.2.2 of Epic #38 - Intelligent Template Triaging.

### Changes

- **Created `src/notifier/services/label_service.py`**:
  - `TemplateLabelMapper` class with configurable mappings
  - Default mappings from TaskType to GitHub labels:
    - PLAN → agent:queued, orchestration:dispatch
    - BUG → agent:queued, bug
    - FEATURE/ENHANCEMENT → agent:queued, enhancement
  - Environment variable support via `LABEL_MAPPINGS` JSON
  - Feature flag `ENABLE_AUTO_TRIAGE` (default: true)
  - `TriageService` combining parser and mapper
  - Skip triaging for issues with existing agent labels

- **Added comprehensive unit tests** in `tests/unit/test_label_service.py`:
  - 52 test cases covering all mapping scenarios
  - Environment variable configuration tests
  - Integration tests with parser

### Test Plan
- [x] All unit tests pass (429 total)
- [x] Default mappings verified for all TaskTypes
- [x] Custom mappings override defaults correctly
- [x] Feature flag disables auto-triage
- [x] Issues with existing agent labels are skipped

Depends on #39 (Story 2.2.1)

Part of #38