### PR TITLE
feat: Local-to-Cloud Tunneling (Phase 2, Task 2.3)

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,449 @@
+# Local Development Setup
+
+This guide explains how to set up local development for the Notifier Service with tunneling support, allowing you to receive GitHub webhooks on your local machine without deploying to a cloud environment.
+
+## Overview
+
+The Local-to-Cloud Tunneling feature enables developers to:
+- Receive GitHub webhooks on their local machines
+- Test webhook flows without cloud deployment
+- Debug webhook handling in real-time
+- Develop and test integrations quickly
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Developer Machine                          │
+│                                                              │
+│  ┌─────────────────────┐    ┌─────────────────────────────┐ │
+│  │  start_dev_notifier │    │     FastAPI Notifier        │ │
+│  │       .sh           │───▶│   (localhost:8000)          │ │
+│  │                     │    │                             │ │
+│  │  • Starts tunnel    │    │  • Webhook endpoint         │ │
+│  │  • Starts FastAPI   │    │  • Signature validation     │ │
+│  │  • Logs public URL  │    │  • Event processing         │ │
+│  └─────────────────────┘    └─────────────────────────────┘ │
+│                                        ▲                     │
+└────────────────────────────────────────│─────────────────────┘
+                                         │
+                              ┌──────────┴──────────┐
+                              │   Tunnel Service    │
+                              │   (ngrok/Tailscale) │
+                              │                     │
+                              │  Public URL:        │
+                              │  https://xxx.ngrok.io
+                              └──────────┬──────────┘
+                                         │
+                                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                       GitHub Webhooks                        │
+│                                                              │
+│  • issues.opened                                            │
+│  • issue_comment.created                                    │
+│  • pull_request_review.submitted                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+### Required
+
+- **Python 3.12+** - Runtime environment
+- **uv** - Python package manager ([install guide](https://docs.astral.sh/uv/))
+- **Git** - Version control
+
+### For Tunneling (choose one)
+
+#### Option A: ngrok
+
+1. **Install ngrok**
+   ```bash
+   # macOS
+   brew install ngrok
+
+   # Linux
+   curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
+   echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
+   sudo apt update && sudo apt install ngrok
+
+   # Windows (via Chocolatey)
+   choco install ngrok
+   ```
+
+2. **Create a free account** at [ngrok.com](https://ngrok.com)
+
+3. **Configure your authtoken**
+   ```bash
+   ngrok config add-authtoken YOUR_TOKEN
+   ```
+
+#### Option B: Tailscale
+
+1. **Install Tailscale**
+   ```bash
+   # macOS
+   brew install tailscale
+
+   # Linux
+   curl -fsSL https://tailscale.com/install.sh | sh
+
+   # Windows
+   # Download from https://tailscale.com/download
+   ```
+
+2. **Connect to Tailscale**
+   ```bash
+   tailscale up
+   ```
+
+3. **Enable Funnel** (requires admin approval)
+   - Go to your [Tailscale Admin Console](https://login.tailscale.com/admin/dns)
+   - Enable Funnel for your tailnet
+
+## Quick Start
+
+### 1. Clone and Setup
+
+```bash
+git clone https://github.com/intel-agency/workflow-orchestration-queue-foxtrot86.git
+cd workflow-orchestration-queue-foxtrot86
+```
+
+### 2. Set Environment Variables
+
+```bash
+# Required: Webhook secret for HMAC verification
+export GITHUB_WEBHOOK_SECRET="your-webhook-secret-here"
+
+# Optional: Choose tunnel type (default: ngrok)
+export TUNNEL_TYPE="ngrok"  # or "tailscale"
+
+# Optional: Change FastAPI port
+export FASTAPI_PORT="8000"
+```
+
+### 3. Start Development Environment
+
+```bash
+# Start with ngrok (default)
+./scripts/start_dev_notifier.sh
+
+# Or with Tailscale
+./scripts/start_dev_notifier.sh --tailscale
+
+# Or without tunnel (local testing only)
+./scripts/start_dev_notifier.sh --no-tunnel
+```
+
+### 4. Configure GitHub Webhook
+
+Once the service is running, you'll see output like:
+
+```
+==============================================
+  Services are running!
+==============================================
+
+Public Webhook URL:
+  https://abc123.ngrok.io/webhooks/github
+
+Configure this URL in your GitHub webhook settings:
+  1. Go to your repository settings
+  2. Navigate to Webhooks
+  3. Add webhook with the URL above
+  4. Set Content type to 'application/json'
+  5. Set Secret to your GITHUB_WEBHOOK_SECRET
+```
+
+## Configuration Options
+
+### Command Line Options
+
+| Option | Description |
+|--------|-------------|
+| `--ngrok` | Use ngrok for tunneling (default) |
+| `--tailscale` | Use Tailscale Funnel for tunneling |
+| `--port PORT` | Local port for FastAPI (default: 8000) |
+| `--no-tunnel` | Start only FastAPI without tunnel |
+| `--auto-configure` | Attempt to auto-configure GitHub webhook URL |
+| `--help` | Show help message |
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GITHUB_WEBHOOK_SECRET` | Secret for HMAC signature verification | Required |
+| `TUNNEL_TYPE` | Tunnel type to use (`ngrok` or `tailscale`) | `ngrok` |
+| `FASTAPI_PORT` | Local port for FastAPI server | `8000` |
+| `WEBHOOK_PUBLIC_URL` | Set by the launcher script | Auto-detected |
+
+## Usage Examples
+
+### Basic Usage
+
+```bash
+# Set webhook secret
+export GITHUB_WEBHOOK_SECRET="my-super-secret-key"
+
+# Start with default settings
+./scripts/start_dev_notifier.sh
+```
+
+### Custom Port
+
+```bash
+# Use port 3000 instead of 8000
+./scripts/start_dev_notifier.sh --port 3000
+```
+
+### Tailscale Funnel
+
+```bash
+# Use Tailscale instead of ngrok
+./scripts/start_dev_notifier.sh --tailscale
+```
+
+### Local Testing (No Tunnel)
+
+```bash
+# Start without tunnel for local API testing
+./scripts/start_dev_notifier.sh --no-tunnel
+
+# Test locally
+curl http://localhost:8000/health
+```
+
+## Local Endpoints
+
+When running locally, these endpoints are available:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /health` | Health check |
+| `GET /ready` | Readiness check |
+| `GET /docs` | OpenAPI documentation (Swagger UI) |
+| `GET /redoc` | ReDoc documentation |
+| `POST /webhooks/github` | GitHub webhook endpoint |
+
+## Testing Webhooks
+
+### Using curl
+
+```bash
+# Generate signature (requires webhook secret)
+SECRET="your-webhook-secret"
+PAYLOAD='{"action":"opened","issue":{"number":1,"title":"Test"}}'
+SIGNATURE=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/.*= //')
+
+# Send test webhook
+curl -X POST http://localhost:8000/webhooks/github \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: issues" \
+  -H "X-GitHub-Delivery: test-123" \
+  -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
+  -d "$PAYLOAD"
+```
+
+### Using ngrok Web Interface
+
+When using ngrok, you can inspect requests at:
+- `http://localhost:4040` - ngrok web interface
+
+### Using GitHub Webhook Delivery
+
+After configuring your webhook in GitHub:
+1. Go to repository Settings > Webhooks
+2. Click on your webhook
+3. Scroll to "Recent Deliveries"
+4. Click on a delivery to inspect the request/response
+
+## Troubleshooting
+
+### Common ngrok Issues
+
+#### "ngrok is not configured"
+
+**Problem:** ngrok authtoken not set.
+
+**Solution:**
+```bash
+ngrok config add-authtoken YOUR_TOKEN
+```
+
+#### "Tunnel session expired" (Free Tier)
+
+**Problem:** ngrok free tier sessions expire after 2 hours.
+
+**Solution:**
+- Restart the script to create a new tunnel
+- Update the webhook URL in GitHub settings
+
+#### "Account limited to 1 endpoint"
+
+**Problem:** Free tier allows only one tunnel at a time.
+
+**Solution:**
+- Stop any other ngrok processes
+- Check for stray processes: `ps aux | grep ngrok`
+- Kill existing tunnels: `pkill ngrok`
+
+#### "Rate limited"
+
+**Problem:** Too many requests on free tier.
+
+**Solution:**
+- Upgrade to ngrok paid plan
+- Use Tailscale as alternative
+
+### Common Tailscale Issues
+
+#### "Tailscale is not connected"
+
+**Problem:** Tailscale daemon not running or not authenticated.
+
+**Solution:**
+```bash
+# Check status
+tailscale status
+
+# Connect
+tailscale up
+```
+
+#### "Funnel not enabled"
+
+**Problem:** Funnel feature not enabled for your tailnet.
+
+**Solution:**
+1. Go to [Tailscale Admin Console](https://login.tailscale.com/admin/dns)
+2. Enable Funnel in DNS settings
+3. Wait for propagation (can take a few minutes)
+
+#### "Permission denied"
+
+**Problem:** Funnel requires specific permissions.
+
+**Solution:**
+- Contact your Tailscale admin
+- Ensure your account has Funnel permissions
+
+### General Issues
+
+#### "Port already in use"
+
+**Problem:** Another process is using port 8000.
+
+**Solution:**
+```bash
+# Find process using port
+lsof -i :8000
+
+# Kill the process
+kill -9 <PID>
+
+# Or use a different port
+./scripts/start_dev_notifier.sh --port 3000
+```
+
+#### "GITHUB_WEBHOOK_SECRET not set"
+
+**Problem:** Environment variable not set.
+
+**Solution:**
+```bash
+export GITHUB_WEBHOOK_SECRET="your-secret"
+./scripts/start_dev_notifier.sh
+```
+
+#### "Signature verification failed"
+
+**Problem:** Webhook secret doesn't match GitHub configuration.
+
+**Solution:**
+1. Verify `GITHUB_WEBHOOK_SECRET` matches GitHub webhook settings
+2. Ensure no trailing whitespace in environment variable
+3. Restart the service after changing the secret
+
+#### "uv not found"
+
+**Problem:** uv package manager not installed.
+
+**Solution:**
+```bash
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Or with pip
+pip install uv
+```
+
+## Security Considerations
+
+### Webhook Secret
+
+- Always use a strong, unique webhook secret
+- Never commit secrets to version control
+- Use environment variables or secure secret storage
+
+### Tunnel Security
+
+- **ngrok:** Free tier tunnels are publicly accessible
+- **Tailscale:** Requires authentication to your tailnet
+- Consider using Tailscale for enhanced security
+
+### Local Development
+
+- The `--no-tunnel` option is for local testing only
+- Do not expose local development servers to the internet
+- Use proper authentication in production
+
+## Advanced Configuration
+
+### Programmatic Tunnel URL Discovery
+
+You can use the tunnel manager programmatically:
+
+```python
+import asyncio
+from src.notifier.tunnel_manager import (
+    TunnelType,
+    get_tunnel_manager,
+    discover_tunnel_url,
+)
+
+async def get_webhook_url():
+    # Simple discovery
+    url = await discover_tunnel_url(TunnelType.NGROK)
+    print(f"Tunnel URL: {url}")
+
+    # With manager
+    manager = get_tunnel_manager(TunnelType.NGROK)
+    if manager.is_available():
+        url = await manager.get_public_url()
+        webhook_url = manager.get_webhook_url("/webhooks/github")
+        print(f"Webhook URL: {webhook_url}")
+
+asyncio.run(get_webhook_url())
+```
+
+### Custom Tunnel Configuration
+
+```python
+from src.notifier.tunnel_manager import NgrokTunnelManager
+
+# Custom ngrok API endpoint
+manager = NgrokTunnelManager(
+    api_host="custom-host",
+    api_port=8080,
+    timeout=30.0,
+)
+```
+
+## Related Documentation
+
+- [Notifier Service Documentation](../src/notifier_service.py)
+- [Tunnel Manager Module](../src/notifier/tunnel_manager.py)
+- [GitHub Webhooks Documentation](https://docs.github.com/en/developers/webhooks-and-events/webhooks)
+- [ngrok Documentation](https://ngrok.com/docs/)
+- [Tailscale Funnel Documentation](https://tailscale.com/kb/1223/tailscale-funnel/)

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -27,13 +27,13 @@ The Local-to-Cloud Tunneling feature enables developers to:
 │                                        ▲                     │
 └────────────────────────────────────────│─────────────────────┘
                                          │
-                              ┌──────────┴──────────┐
-                              │   Tunnel Service    │
-                              │   (ngrok/Tailscale) │
-                              │                     │
-                              │  Public URL:        │
-                              │  https://xxx.ngrok.io
-                              └──────────┬──────────┘
+                               ┌──────────┴──────────┐
+                               │   Tunnel Service    │
+                               │   (ngrok/Tailscale) │
+                               │                     │
+                               │  Public URL:        │
+                               │  https://xxx.ngrok.io  (xxx = dynamically generated)
+                               └──────────┬──────────┘
                                          │
                                          ▼
 ┌─────────────────────────────────────────────────────────────┐

--- a/scripts/start_dev_notifier.sh
+++ b/scripts/start_dev_notifier.sh
@@ -1,0 +1,476 @@
+#!/bin/bash
+#
+# Development Launcher Script for Notifier Service with Tunnel Support
+#
+# This script orchestrates the startup of both the tunnel service (ngrok or Tailscale)
+# and the FastAPI notifier service for local webhook development.
+#
+# Story 3.1: Development Launcher Script
+#
+# Usage:
+#   ./scripts/start_dev_notifier.sh [options]
+#
+# Options:
+#   --ngrok          Use ngrok for tunneling (default)
+#   --tailscale      Use Tailscale Funnel for tunneling
+#   --port PORT      Local port for FastAPI (default: 8000)
+#   --no-tunnel      Start only FastAPI without tunnel
+#   --auto-configure Attempt to auto-configure GitHub webhook URL
+#   --help           Show this help message
+#
+# Environment Variables:
+#   TUNNEL_TYPE      Tunnel type to use (ngrok or tailscale)
+#   FASTAPI_PORT     Local port for FastAPI server
+#   GITHUB_WEBHOOK_SECRET  Secret for HMAC signature verification
+#
+# Prerequisites:
+#   - ngrok: Install from https://ngrok.com and configure authtoken
+#   - Tailscale: Install from https://tailscale.com and run `tailscale up`
+#
+# Examples:
+#   # Start with ngrok (default)
+#   ./scripts/start_dev_notifier.sh
+#
+#   # Start with Tailscale Funnel
+#   ./scripts/start_dev_notifier.sh --tailscale
+#
+#   # Use custom port
+#   ./scripts/start_dev_notifier.sh --port 3000
+#
+#   # Start without tunnel (for local testing only)
+#   ./scripts/start_dev_notifier.sh --no-tunnel
+
+set -euo pipefail
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Default values
+TUNNEL_TYPE="${TUNNEL_TYPE:-ngrok}"
+FASTAPI_PORT="${FASTAPI_PORT:-8000}"
+USE_TUNNEL=true
+AUTO_CONFIGURE=false
+NGROK_API_PORT=4040
+
+# Process tracking
+TUNNEL_PID=""
+FASTAPI_PID=""
+CLEANUP_DONE=false
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_step() {
+    echo -e "${CYAN}[STEP]${NC} $1"
+}
+
+log_url() {
+    echo -e "${BLUE}[URL]${NC} $1"
+}
+
+show_help() {
+    sed -n '/^# Usage:/,/^#$/p' "$0" | head -n -1 | tail -n +2 | sed 's/^# //'
+    exit 0
+}
+
+cleanup() {
+    if [[ "$CLEANUP_DONE" == "true" ]]; then
+        return
+    fi
+    CLEANUP_DONE=true
+
+    echo ""
+    log_info "Shutting down services..."
+
+    # Kill tunnel process first
+    if [[ -n "$TUNNEL_PID" ]] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
+        log_info "Stopping tunnel (PID: $TUNNEL_PID)..."
+        kill "$TUNNEL_PID" 2>/dev/null || true
+        wait "$TUNNEL_PID" 2>/dev/null || true
+    fi
+
+    # Kill FastAPI process
+    if [[ -n "$FASTAPI_PID" ]] && kill -0 "$FASTAPI_PID" 2>/dev/null; then
+        log_info "Stopping FastAPI (PID: $FASTAPI_PID)..."
+        kill "$FASTAPI_PID" 2>/dev/null || true
+        wait "$FASTAPI_PID" 2>/dev/null || true
+    fi
+
+    log_info "Cleanup complete. Goodbye!"
+}
+
+# Set up signal handlers for graceful shutdown
+trap cleanup SIGINT SIGTERM EXIT
+
+# ==============================================================================
+# Argument Parsing
+# ==============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ngrok)
+            TUNNEL_TYPE="ngrok"
+            shift
+            ;;
+        --tailscale)
+            TUNNEL_TYPE="tailscale"
+            shift
+            ;;
+        --port)
+            FASTAPI_PORT="$2"
+            shift 2
+            ;;
+        --no-tunnel)
+            USE_TUNNEL=false
+            shift
+            ;;
+        --auto-configure)
+            AUTO_CONFIGURE=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# ==============================================================================
+# Validation
+# ==============================================================================
+
+validate_dependencies() {
+    log_step "Validating dependencies..."
+
+    # Check for Python/uv
+    if ! command -v uv &>/dev/null; then
+        log_error "uv is not installed. Please install it first."
+        log_error "See: https://docs.astral.sh/uv/"
+        exit 1
+    fi
+
+    # Check webhook secret
+    if [[ -z "${GITHUB_WEBHOOK_SECRET:-}" ]]; then
+        log_warn "GITHUB_WEBHOOK_SECRET is not set."
+        log_warn "Webhook signature verification will fail."
+        log_warn "Set it with: export GITHUB_WEBHOOK_SECRET=your-secret"
+    fi
+
+    if [[ "$USE_TUNNEL" == "true" ]]; then
+        if [[ "$TUNNEL_TYPE" == "ngrok" ]]; then
+            if ! command -v ngrok &>/dev/null; then
+                log_error "ngrok is not installed."
+                log_error "Install from: https://ngrok.com/download"
+                exit 1
+            fi
+
+            # Check if ngrok is configured
+            if ! ngrok config check &>/dev/null 2>&1; then
+                log_error "ngrok is not configured."
+                log_error "Run: ngrok config add-authtoken YOUR_TOKEN"
+                exit 1
+            fi
+            log_info "ngrok is available and configured"
+        elif [[ "$TUNNEL_TYPE" == "tailscale" ]]; then
+            if ! command -v tailscale &>/dev/null; then
+                log_error "Tailscale is not installed."
+                log_error "Install from: https://tailscale.com/download"
+                exit 1
+            fi
+
+            # Check if Tailscale is connected
+            if ! tailscale status &>/dev/null; then
+                log_error "Tailscale is not connected."
+                log_error "Run: tailscale up"
+                exit 1
+            fi
+            log_info "Tailscale is available and connected"
+        fi
+    fi
+
+    log_info "All dependencies validated"
+}
+
+# ==============================================================================
+# Tunnel Functions
+# ==============================================================================
+
+start_ngrok_tunnel() {
+    log_step "Starting ngrok tunnel on port $FASTAPI_PORT..."
+
+    # Start ngrok in background
+    ngrok http "$FASTAPI_PORT" --log=stdout > /dev/null 2>&1 &
+    TUNNEL_PID=$!
+
+    log_info "ngrok started (PID: $TUNNEL_PID)"
+
+    # Wait for ngrok API to be ready
+    log_info "Waiting for ngrok API to be ready..."
+    local max_attempts=30
+    local attempt=0
+
+    while [[ $attempt -lt $max_attempts ]]; do
+        if curl -s "http://localhost:$NGROK_API_PORT/api/tunnels" > /dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+        ((attempt++))
+    done
+
+    if [[ $attempt -eq $max_attempts ]]; then
+        log_error "ngrok API did not become ready in time"
+        exit 1
+    fi
+
+    # Get the public URL
+    local tunnel_info
+    tunnel_info=$(curl -s "http://localhost:$NGROK_API_PORT/api/tunnels")
+
+    # Extract HTTPS URL (prefer HTTPS over HTTP)
+    local public_url
+    public_url=$(echo "$tunnel_info" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    tunnels = data.get('tunnels', [])
+    for t in tunnels:
+        url = t.get('public_url', '')
+        if url.startswith('https://'):
+            print(url)
+            break
+    else:
+        for t in tunnels:
+            url = t.get('public_url', '')
+            if url.startswith('http://'):
+                print(url)
+                break
+except Exception:
+    pass
+" 2>/dev/null)
+
+    if [[ -z "$public_url" ]]; then
+        log_error "Could not extract ngrok public URL"
+        exit 1
+    fi
+
+    PUBLIC_URL="$public_url"
+    log_info "ngrok tunnel established"
+}
+
+start_tailscale_tunnel() {
+    log_step "Starting Tailscale Funnel on port $FASTAPI_PORT..."
+
+    # Check if funnel is available
+    if ! tailscale funnel status &>/dev/null 2>&1; then
+        log_warn "Tailscale Funnel may not be enabled for this machine."
+        log_warn "You may need to enable it in the Tailscale admin console."
+    fi
+
+    # Start tailscale funnel in background
+    tailscale funnel "$FASTAPI_PORT" > /dev/null 2>&1 &
+    TUNNEL_PID=$!
+
+    log_info "Tailscale Funnel started (PID: $TUNNEL_PID)"
+
+    # Get the funnel URL from tailscale status
+    local dns_name
+    dns_name=$(tailscale status --json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    self_node = data.get('Self', {})
+    dns_name = self_node.get('DNSName', '')
+    print(dns_name.rstrip('.'))
+except Exception:
+    pass
+" 2>/dev/null)
+
+    if [[ -z "$dns_name" ]]; then
+        log_error "Could not determine Tailscale DNS name"
+        exit 1
+    fi
+
+    PUBLIC_URL="https://${dns_name}"
+    log_info "Tailscale Funnel URL determined"
+}
+
+get_tunnel_url() {
+    if [[ "$TUNNEL_TYPE" == "ngrok" ]]; then
+        start_ngrok_tunnel
+    elif [[ "$TUNNEL_TYPE" == "tailscale" ]]; then
+        start_tailscale_tunnel
+    fi
+}
+
+# ==============================================================================
+# GitHub Webhook Configuration (Bonus - Story 3.3)
+# ==============================================================================
+
+configure_github_webhook() {
+    if [[ "$AUTO_CONFIGURE" != "true" ]]; then
+        return
+    fi
+
+    log_step "Attempting GitHub webhook auto-configuration..."
+
+    local webhook_url="${PUBLIC_URL}/webhooks/github"
+    local github_app_id="${GITHUB_APP_ID:-}"
+    local github_app_pem="${GITHUB_APP_PEM:-}"
+
+    if [[ -z "$github_app_id" ]] || [[ -z "$github_app_pem" ]]; then
+        log_warn "GitHub App credentials not configured."
+        log_warn "Set GITHUB_APP_ID and GITHUB_APP_PEM for auto-configuration."
+        return
+    fi
+
+    # Note: Full implementation would use JWT authentication
+    # This is a placeholder for the bonus feature
+    log_warn "GitHub webhook auto-configuration is not yet fully implemented."
+    log_warn "Please configure manually using the URL below."
+}
+
+# ==============================================================================
+# FastAPI Service
+# ==============================================================================
+
+start_fastapi() {
+    log_step "Starting FastAPI notifier service on port $FASTAPI_PORT..."
+
+    # Export environment variables for the service
+    export WEBHOOK_PUBLIC_URL="${PUBLIC_URL:-http://localhost:$FASTAPI_PORT}"
+
+    cd "$PROJECT_ROOT"
+
+    # Start uvicorn with uv
+    uv run uvicorn src.notifier_service:app \
+        --host 0.0.0.0 \
+        --port "$FASTAPI_PORT" \
+        --reload \
+        > /dev/null 2>&1 &
+
+    FASTAPI_PID=$!
+    log_info "FastAPI started (PID: $FASTAPI_PID)"
+
+    # Wait for FastAPI to be ready
+    log_info "Waiting for FastAPI to be ready..."
+    local max_attempts=30
+    local attempt=0
+
+    while [[ $attempt -lt $max_attempts ]]; do
+        if curl -s "http://localhost:$FASTAPI_PORT/health" > /dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+        ((attempt++))
+    done
+
+    if [[ $attempt -eq $max_attempts ]]; then
+        log_error "FastAPI did not become ready in time"
+        exit 1
+    fi
+
+    log_info "FastAPI is ready"
+}
+
+# ==============================================================================
+# Main Execution
+# ==============================================================================
+
+main() {
+    echo ""
+    echo "=============================================="
+    echo "  Notifier Development Launcher"
+    echo "  Phase 2 - Local-to-Cloud Tunneling"
+    echo "=============================================="
+    echo ""
+
+    validate_dependencies
+
+    # Initialize PUBLIC_URL
+    PUBLIC_URL="http://localhost:$FASTAPI_PORT"
+
+    # Start tunnel if requested
+    if [[ "$USE_TUNNEL" == "true" ]]; then
+        get_tunnel_url
+    else
+        log_info "Running without tunnel (local access only)"
+    fi
+
+    # Attempt GitHub webhook configuration (bonus feature)
+    configure_github_webhook
+
+    # Start FastAPI
+    start_fastapi
+
+    # Display summary
+    echo ""
+    echo "=============================================="
+    log_info "Services are running!"
+    echo "=============================================="
+    echo ""
+
+    if [[ "$USE_TUNNEL" == "true" ]]; then
+        echo -e "${GREEN}Public Webhook URL:${NC}"
+        log_url "${PUBLIC_URL}/webhooks/github"
+        echo ""
+        echo -e "${YELLOW}Configure this URL in your GitHub webhook settings:${NC}"
+        echo "  1. Go to your repository settings"
+        echo "  2. Navigate to Webhooks"
+        echo "  3. Add webhook with the URL above"
+        echo "  4. Set Content type to 'application/json'"
+        echo "  5. Set Secret to your GITHUB_WEBHOOK_SECRET"
+        echo ""
+    fi
+
+    echo -e "${GREEN}Local Endpoints:${NC}"
+    log_url "http://localhost:$FASTAPI_PORT/health"
+    log_url "http://localhost:$FASTAPI_PORT/docs"
+    log_url "http://localhost:$FASTAPI_PORT/webhooks/github"
+    echo ""
+
+    if [[ "$TUNNEL_TYPE" == "ngrok" ]] && [[ "$USE_TUNNEL" == "true" ]]; then
+        echo -e "${GREEN}ngrok Web Interface:${NC}"
+        log_url "http://localhost:$NGROK_API_PORT"
+        echo ""
+    fi
+
+    echo "=============================================="
+    echo -e "${YELLOW}Press Ctrl+C to stop all services${NC}"
+    echo "=============================================="
+    echo ""
+
+    # Keep script running and wait for processes
+    wait
+}
+
+# Run main function
+main

--- a/scripts/start_dev_notifier.sh
+++ b/scripts/start_dev_notifier.sh
@@ -55,6 +55,8 @@ FASTAPI_PORT="${FASTAPI_PORT:-8000}"
 USE_TUNNEL=true
 AUTO_CONFIGURE=false
 NGROK_API_PORT=4040
+LOG_DIR="${PROJECT_ROOT}/logs"
+LOG_FILE="${LOG_DIR}/dev_notifier.log"
 
 # Process tracking
 TUNNEL_PID=""
@@ -94,7 +96,42 @@ log_url() {
 }
 
 show_help() {
-    sed -n '/^# Usage:/,/^#$/p' "$0" | head -n -1 | tail -n +2 | sed 's/^# //'
+    cat << 'EOF'
+Development Launcher Script for Notifier Service with Tunnel Support
+
+Usage:
+  ./scripts/start_dev_notifier.sh [options]
+
+Options:
+  --ngrok          Use ngrok for tunneling (default)
+  --tailscale      Use Tailscale Funnel for tunneling
+  --port PORT      Local port for FastAPI (default: 8000)
+  --no-tunnel      Start only FastAPI without tunnel
+  --auto-configure Attempt to auto-configure GitHub webhook URL
+  --help           Show this help message
+
+Environment Variables:
+  TUNNEL_TYPE      Tunnel type to use (ngrok or tailscale)
+  FASTAPI_PORT     Local port for FastAPI server
+  GITHUB_WEBHOOK_SECRET  Secret for HMAC signature verification
+
+Prerequisites:
+  - ngrok: Install from https://ngrok.com and configure authtoken
+  - Tailscale: Install from https://tailscale.com and run `tailscale up`
+
+Examples:
+  # Start with ngrok (default)
+  ./scripts/start_dev_notifier.sh
+
+  # Start with Tailscale Funnel
+  ./scripts/start_dev_notifier.sh --tailscale
+
+  # Use custom port
+  ./scripts/start_dev_notifier.sh --port 3000
+
+  # Start without tunnel (for local testing only)
+  ./scripts/start_dev_notifier.sh --no-tunnel
+EOF
     exit 0
 }
 
@@ -227,8 +264,12 @@ validate_dependencies() {
 start_ngrok_tunnel() {
     log_step "Starting ngrok tunnel on port $FASTAPI_PORT..."
 
-    # Start ngrok in background
-    ngrok http "$FASTAPI_PORT" --log=stdout > /dev/null 2>&1 &
+    # Ensure log directory exists
+    mkdir -p "$LOG_DIR"
+
+    # Start ngrok in background with logging
+    log_info "Logging ngrok output to: $LOG_FILE"
+    ngrok http "$FASTAPI_PORT" --log=stdout >> "$LOG_FILE" 2>&1 &
     TUNNEL_PID=$!
 
     log_info "ngrok started (PID: $TUNNEL_PID)"
@@ -295,8 +336,12 @@ start_tailscale_tunnel() {
         log_warn "You may need to enable it in the Tailscale admin console."
     fi
 
-    # Start tailscale funnel in background
-    tailscale funnel "$FASTAPI_PORT" > /dev/null 2>&1 &
+    # Ensure log directory exists
+    mkdir -p "$LOG_DIR"
+
+    # Start tailscale funnel in background with logging
+    log_info "Logging Tailscale output to: $LOG_FILE"
+    tailscale funnel "$FASTAPI_PORT" >> "$LOG_FILE" 2>&1 &
     TUNNEL_PID=$!
 
     log_info "Tailscale Funnel started (PID: $TUNNEL_PID)"
@@ -370,12 +415,16 @@ start_fastapi() {
 
     cd "$PROJECT_ROOT"
 
-    # Start uvicorn with uv
+    # Ensure log directory exists
+    mkdir -p "$LOG_DIR"
+
+    # Start uvicorn with uv - log output for debugging
+    log_info "Logging FastAPI output to: $LOG_FILE"
     uv run uvicorn src.notifier_service:app \
         --host 0.0.0.0 \
         --port "$FASTAPI_PORT" \
         --reload \
-        > /dev/null 2>&1 &
+        >> "$LOG_FILE" 2>&1 &
 
     FASTAPI_PID=$!
     log_info "FastAPI started (PID: $FASTAPI_PID)"
@@ -412,6 +461,10 @@ main() {
     echo "  Phase 2 - Local-to-Cloud Tunneling"
     echo "=============================================="
     echo ""
+
+    # Create log directory
+    mkdir -p "$LOG_DIR"
+    log_info "Logs will be written to: $LOG_FILE"
 
     validate_dependencies
 

--- a/src/notifier/tunnel_manager.py
+++ b/src/notifier/tunnel_manager.py
@@ -1,0 +1,504 @@
+"""
+Tunnel URL Discovery for Local-to-Cloud Tunneling.
+
+This module provides tunnel URL discovery for ngrok and Tailscale,
+enabling local webhook reception during development.
+
+Story 3.2: Tunnel URL Discovery
+
+Usage:
+    from src.notifier.tunnel_manager import get_tunnel_manager, TunnelType
+
+    manager = get_tunnel_manager(TunnelType.NGROK)
+    url = await manager.get_public_url()
+    print(f"Webhook URL: {url}")
+"""
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("tunnel_manager")
+
+
+class TunnelType(str, Enum):
+    """Supported tunnel types."""
+
+    NGROK = "ngrok"
+    TAILSCALE = "tailscale"
+
+
+class TunnelError(Exception):
+    """Base exception for tunnel-related errors."""
+
+    pass
+
+
+class TunnelNotReadyError(TunnelError):
+    """Raised when the tunnel is not ready or accessible."""
+
+    pass
+
+
+class TunnelAPIError(TunnelError):
+    """Raised when the tunnel API returns an error."""
+
+    pass
+
+
+class TunnelManager(ABC):
+    """
+    Abstract base class for tunnel URL discovery.
+
+    Subclasses implement specific tunnel provider logic for
+    retrieving the public URL of a running tunnel.
+    """
+
+    @abstractmethod
+    async def get_public_url(self) -> str:
+        """
+        Get the public URL of the running tunnel.
+
+        Returns:
+            The public HTTPS URL of the tunnel.
+
+        Raises:
+            TunnelNotReadyError: If the tunnel is not ready.
+            TunnelAPIError: If there's an error communicating with the tunnel API.
+        """
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Check if the tunnel provider is available on this system.
+
+        Returns:
+            True if the tunnel binary/service is available.
+        """
+        pass
+
+    def get_webhook_url(self, path: str = "/webhooks/github") -> str:
+        """
+        Get the full webhook URL for a given path.
+
+        Args:
+            path: The webhook endpoint path.
+
+        Returns:
+            The complete webhook URL.
+        """
+        # This is a sync method that should be called after get_public_url
+        # Subclasses can override if they need async behavior
+        raise NotImplementedError("Subclasses should implement get_webhook_url")
+
+
+class NgrokTunnelManager(TunnelManager):
+    """
+    Tunnel URL discovery for ngrok.
+
+    Queries the ngrok API at localhost:4040 to retrieve the public URL
+    of the running tunnel.
+
+    Prerequisites:
+        - ngrok must be installed and in PATH
+        - ngrok must be running (e.g., `ngrok http 8000`)
+        - ngrok API must be accessible at localhost:4040
+    """
+
+    def __init__(
+        self,
+        api_host: str = "localhost",
+        api_port: int = 4040,
+        timeout: float = 10.0,
+    ):
+        """
+        Initialize the ngrok tunnel manager.
+
+        Args:
+            api_host: Host where ngrok API is running.
+            api_port: Port where ngrok API is running.
+            timeout: Timeout for API requests in seconds.
+        """
+        self.api_host = api_host
+        self.api_port = api_port
+        self.timeout = timeout
+        self._cached_url: str | None = None
+
+    @property
+    def api_url(self) -> str:
+        """Get the ngrok API base URL."""
+        return f"http://{self.api_host}:{self.api_port}"
+
+    def is_available(self) -> bool:
+        """
+        Check if ngrok is available on this system.
+
+        Returns:
+            True if ngrok binary is found in PATH.
+        """
+        try:
+            result = subprocess.run(
+                ["which", "ngrok"],
+                capture_output=True,
+                text=True,
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return False
+
+    async def get_public_url(self) -> str:
+        """
+        Get the public URL from the ngrok API.
+
+        Queries the ngrok tunnels API to find the public HTTPS URL.
+
+        Returns:
+            The public HTTPS URL of the ngrok tunnel.
+
+        Raises:
+            TunnelNotReadyError: If ngrok API is not accessible.
+            TunnelAPIError: If no tunnel is found or API returns an error.
+        """
+        if self._cached_url:
+            return self._cached_url
+
+        tunnels_url = f"{self.api_url}/api/tunnels"
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(tunnels_url)
+                response.raise_for_status()
+                data = response.json()
+
+            tunnels = data.get("tunnels", [])
+            if not tunnels:
+                raise TunnelAPIError(
+                    "No ngrok tunnels found. Is ngrok running with 'ngrok http <port>'?"
+                )
+
+            # Find the HTTPS tunnel (prefer https over http)
+            https_tunnel = None
+            for tunnel in tunnels:
+                public_url = tunnel.get("public_url", "")
+                if public_url.startswith("https://"):
+                    https_tunnel = tunnel
+                    break
+                elif public_url.startswith("http://") and https_tunnel is None:
+                    https_tunnel = tunnel
+
+            if https_tunnel is None:
+                raise TunnelAPIError("No public tunnel found in ngrok API response")
+
+            public_url = https_tunnel.get("public_url", "")
+            if not public_url:
+                raise TunnelAPIError("Tunnel found but no public_url in response")
+
+            self._cached_url = public_url
+            logger.info(f"Discovered ngrok public URL: {public_url}")
+            return public_url
+
+        except httpx.ConnectError as e:
+            raise TunnelNotReadyError(
+                f"Cannot connect to ngrok API at {tunnels_url}. "
+                "Is ngrok running? Start with 'ngrok http <port>'"
+            ) from e
+        except httpx.HTTPStatusError as e:
+            raise TunnelAPIError(
+                f"ngrok API returned error: {e.response.status_code}"
+            ) from e
+        except httpx.RequestError as e:
+            raise TunnelAPIError(f"Error querying ngrok API: {e}") from e
+
+    async def wait_for_ready(
+        self,
+        max_attempts: int = 30,
+        delay: float = 1.0,
+    ) -> str:
+        """
+        Wait for the ngrok tunnel to be ready and return the public URL.
+
+        Polls the ngrok API until it responds with a valid tunnel URL
+        or until max_attempts is reached.
+
+        Args:
+            max_attempts: Maximum number of polling attempts.
+            delay: Delay between attempts in seconds.
+
+        Returns:
+            The public HTTPS URL of the ngrok tunnel.
+
+        Raises:
+            TunnelNotReadyError: If tunnel is not ready within the timeout.
+        """
+        last_error: Exception | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return await self.get_public_url()
+            except (TunnelNotReadyError, TunnelAPIError) as e:
+                last_error = e
+                if attempt < max_attempts:
+                    logger.debug(
+                        f"Waiting for ngrok to be ready (attempt {attempt}/{max_attempts})"
+                    )
+                    await asyncio.sleep(delay)
+
+        raise TunnelNotReadyError(
+            f"ngrok tunnel not ready after {max_attempts} attempts"
+        ) from last_error
+
+    def get_webhook_url(self, path: str = "/webhooks/github") -> str:
+        """
+        Get the full webhook URL for a given path.
+
+        Args:
+            path: The webhook endpoint path.
+
+        Returns:
+            The complete webhook URL.
+
+        Raises:
+            RuntimeError: If get_public_url hasn't been called yet.
+        """
+        if not self._cached_url:
+            raise RuntimeError("Must call get_public_url() or wait_for_ready() first")
+        return f"{self._cached_url.rstrip('/')}{path}"
+
+
+class TailscaleTunnelManager(TunnelManager):
+    """
+    Tunnel URL discovery for Tailscale Funnel.
+
+    Uses the Tailscale CLI to determine the funnel URL for
+    the local machine.
+
+    Prerequisites:
+        - Tailscale must be installed and authenticated
+        - Tailscale Funnel must be enabled (`tailscale funnel`)
+        - Machine must be on the tailnet
+    """
+
+    def __init__(self, timeout: float = 10.0):
+        """
+        Initialize the Tailscale tunnel manager.
+
+        Args:
+            timeout: Timeout for CLI commands in seconds.
+        """
+        self.timeout = timeout
+        self._cached_url: str | None = None
+
+    def is_available(self) -> bool:
+        """
+        Check if Tailscale is available on this system.
+
+        Returns:
+            True if tailscale binary is found in PATH.
+        """
+        try:
+            result = subprocess.run(
+                ["which", "tailscale"],
+                capture_output=True,
+                text=True,
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return False
+
+    async def get_public_url(self) -> str:
+        """
+        Get the public URL from Tailscale.
+
+        Uses `tailscale status --json` to get the machine's hostname
+        and constructs the funnel URL.
+
+        Returns:
+            The public HTTPS URL for Tailscale Funnel.
+
+        Raises:
+            TunnelNotReadyError: If Tailscale is not connected.
+            TunnelAPIError: If unable to determine the funnel URL.
+        """
+        if self._cached_url:
+            return self._cached_url
+
+        try:
+            # Get Tailscale status as JSON
+            result = subprocess.run(
+                ["tailscale", "status", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+
+            if result.returncode != 0:
+                raise TunnelNotReadyError(f"Tailscale command failed: {result.stderr}")
+
+            data = json.loads(result.stdout)
+
+            # Get the current machine's info
+            self_node = data.get("Self", {})
+            dns_name = self_node.get("DNSName", "")
+
+            if not dns_name:
+                raise TunnelAPIError(
+                    "Could not determine Tailscale DNS name. Is Tailscale connected?"
+                )
+
+            # Remove trailing dot if present
+            dns_name = dns_name.rstrip(".")
+
+            # Construct the funnel URL
+            public_url = f"https://{dns_name}"
+            self._cached_url = public_url
+
+            logger.info(f"Discovered Tailscale funnel URL: {public_url}")
+            return public_url
+
+        except json.JSONDecodeError as e:
+            raise TunnelAPIError(f"Failed to parse Tailscale status output: {e}") from e
+        except subprocess.TimeoutExpired as e:
+            raise TunnelNotReadyError(
+                "Tailscale command timed out. Is Tailscale responsive?"
+            ) from e
+        except subprocess.SubprocessError as e:
+            raise TunnelAPIError(f"Error running tailscale command: {e}") from e
+
+    async def is_funnel_enabled(self) -> bool:
+        """
+        Check if Tailscale Funnel is enabled.
+
+        Returns:
+            True if funnel is enabled for this machine.
+        """
+        try:
+            result = subprocess.run(
+                ["tailscale", "funnel", "status"],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            # Funnel status returns 0 if enabled
+            return result.returncode == 0
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return False
+
+    def get_webhook_url(self, path: str = "/webhooks/github") -> str:
+        """
+        Get the full webhook URL for a given path.
+
+        Args:
+            path: The webhook endpoint path.
+
+        Returns:
+            The complete webhook URL.
+
+        Raises:
+            RuntimeError: If get_public_url hasn't been called yet.
+        """
+        if not self._cached_url:
+            raise RuntimeError("Must call get_public_url() first")
+        return f"{self._cached_url.rstrip('/')}{path}"
+
+
+def get_tunnel_manager(
+    tunnel_type: TunnelType,
+    **kwargs: Any,
+) -> TunnelManager:
+    """
+    Factory function to create a tunnel manager.
+
+    Args:
+        tunnel_type: The type of tunnel (NGROK or TAILSCALE).
+        **kwargs: Additional arguments passed to the tunnel manager constructor.
+
+    Returns:
+        A TunnelManager instance for the specified tunnel type.
+
+    Raises:
+        ValueError: If an unsupported tunnel type is specified.
+    """
+    managers: dict[TunnelType, type[TunnelManager]] = {
+        TunnelType.NGROK: NgrokTunnelManager,
+        TunnelType.TAILSCALE: TailscaleTunnelManager,
+    }
+
+    manager_class = managers.get(tunnel_type)
+    if manager_class is None:
+        raise ValueError(f"Unsupported tunnel type: {tunnel_type}")
+
+    return manager_class(**kwargs)
+
+
+def get_tunnel_type_from_env() -> TunnelType:
+    """
+    Get the tunnel type from environment variable.
+
+    Reads TUNNEL_TYPE environment variable (defaults to 'ngrok').
+
+    Returns:
+        The tunnel type to use.
+    """
+    tunnel_type_str = os.environ.get("TUNNEL_TYPE", "ngrok").lower()
+    try:
+        return TunnelType(tunnel_type_str)
+    except ValueError:
+        logger.warning(f"Unknown TUNNEL_TYPE '{tunnel_type_str}', defaulting to ngrok")
+        return TunnelType.NGROK
+
+
+async def discover_tunnel_url(
+    tunnel_type: TunnelType | None = None,
+    wait: bool = True,
+    max_attempts: int = 30,
+) -> str:
+    """
+    Convenience function to discover the tunnel URL.
+
+    Args:
+        tunnel_type: The tunnel type to use. If None, reads from environment.
+        wait: Whether to wait for the tunnel to be ready.
+        max_attempts: Maximum attempts when waiting.
+
+    Returns:
+        The public tunnel URL.
+
+    Raises:
+        TunnelError: If the tunnel URL cannot be discovered.
+    """
+    if tunnel_type is None:
+        tunnel_type = get_tunnel_type_from_env()
+
+    manager = get_tunnel_manager(tunnel_type)
+
+    if not manager.is_available():
+        raise TunnelError(
+            f"{tunnel_type.value} is not available. "
+            f"Please install {tunnel_type.value} first."
+        )
+
+    if wait and isinstance(manager, NgrokTunnelManager):
+        return await manager.wait_for_ready(max_attempts=max_attempts)
+    else:
+        return await manager.get_public_url()
+
+
+__all__ = [
+    "TunnelType",
+    "TunnelError",
+    "TunnelNotReadyError",
+    "TunnelAPIError",
+    "TunnelManager",
+    "NgrokTunnelManager",
+    "TailscaleTunnelManager",
+    "get_tunnel_manager",
+    "get_tunnel_type_from_env",
+    "discover_tunnel_url",
+]

--- a/src/notifier/tunnel_manager.py
+++ b/src/notifier/tunnel_manager.py
@@ -85,6 +85,7 @@ class TunnelManager(ABC):
         """
         pass
 
+    @abstractmethod
     def get_webhook_url(self, path: str = "/webhooks/github") -> str:
         """
         Get the full webhook URL for a given path.
@@ -95,9 +96,7 @@ class TunnelManager(ABC):
         Returns:
             The complete webhook URL.
         """
-        # This is a sync method that should be called after get_public_url
-        # Subclasses can override if they need async behavior
-        raise NotImplementedError("Subclasses should implement get_webhook_url")
+        pass
 
 
 class NgrokTunnelManager(TunnelManager):
@@ -407,6 +406,43 @@ class TailscaleTunnelManager(TunnelManager):
             raise RuntimeError("Must call get_public_url() first")
         return f"{self._cached_url.rstrip('/')}{path}"
 
+    async def wait_for_ready(
+        self,
+        max_attempts: int = 30,
+        delay: float = 1.0,
+    ) -> str:
+        """
+        Wait for Tailscale Funnel to be ready and return the public URL.
+
+        Polls the Tailscale status until it returns a valid DNS name
+        or until max_attempts is reached.
+
+        Args:
+            max_attempts: Maximum number of polling attempts.
+            delay: Delay between attempts in seconds.
+
+        Returns:
+            The public HTTPS URL for Tailscale Funnel.
+
+        Raises:
+            TunnelNotReadyError: If tunnel is not ready within the timeout.
+        """
+        last_error: Exception | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return await self.get_public_url()
+            except (TunnelNotReadyError, TunnelAPIError) as e:
+                last_error = e
+                if attempt < max_attempts:
+                    logger.debug(
+                        f"Waiting for Tailscale to be ready (attempt {attempt}/{max_attempts})"
+                    )
+                    await asyncio.sleep(delay)
+
+        raise TunnelNotReadyError(
+            f"Tailscale tunnel not ready after {max_attempts} attempts"
+        ) from last_error
+
 
 def get_tunnel_manager(
     tunnel_type: TunnelType,
@@ -484,7 +520,7 @@ async def discover_tunnel_url(
             f"Please install {tunnel_type.value} first."
         )
 
-    if wait and isinstance(manager, NgrokTunnelManager):
+    if wait:
         return await manager.wait_for_ready(max_attempts=max_attempts)
     else:
         return await manager.get_public_url()

--- a/tests/test_tunnel_manager.py
+++ b/tests/test_tunnel_manager.py
@@ -1,0 +1,662 @@
+"""
+Unit tests for Tunnel URL Discovery (Story 3.2).
+
+This module tests the tunnel_manager.py implementations for both
+ngrok and Tailscale tunnel URL discovery.
+
+Tests use mocking to avoid requiring actual tunnel binaries.
+"""
+
+import json
+import os
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.notifier.tunnel_manager import (
+    NgrokTunnelManager,
+    TunnelAPIError,
+    TunnelError,
+    TunnelManager,
+    TunnelNotReadyError,
+    TunnelType,
+    TailscaleTunnelManager,
+    discover_tunnel_url,
+    get_tunnel_manager,
+    get_tunnel_type_from_env,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def ngrok_manager() -> NgrokTunnelManager:
+    """Create an ngrok tunnel manager instance."""
+    return NgrokTunnelManager(api_host="localhost", api_port=4040)
+
+
+@pytest.fixture
+def tailscale_manager() -> TailscaleTunnelManager:
+    """Create a Tailscale tunnel manager instance."""
+    return TailscaleTunnelManager()
+
+
+@pytest.fixture
+def ngrok_tunnels_response() -> dict:
+    """Sample ngrok tunnels API response."""
+    return {
+        "tunnels": [
+            {
+                "id": "tunnel_abc123",
+                "public_url": "https://abc123.ngrok.io",
+                "proto": "https",
+                "config": {
+                    "addr": "http://localhost:8000",
+                },
+            },
+            {
+                "id": "tunnel_def456",
+                "public_url": "http://def456.ngrok.io",
+                "proto": "http",
+                "config": {
+                    "addr": "http://localhost:8000",
+                },
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def tailscale_status_response() -> dict:
+    """Sample Tailscale status JSON response."""
+    return {
+        "Self": {
+            "ID": "node123",
+            "DNSName": "my-machine.tailnet123.ts.net.",
+            "HostName": "my-machine",
+            "Online": True,
+        },
+        "Peer": {},
+    }
+
+
+# ============================================================================
+# TunnelManager Abstract Base Class Tests
+# ============================================================================
+
+
+class TestTunnelManagerAbstract:
+    """Tests for TunnelManager abstract base class."""
+
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        """Test that TunnelManager cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            TunnelManager()  # type: ignore
+
+
+# ============================================================================
+# TunnelType Enum Tests
+# ============================================================================
+
+
+class TestTunnelType:
+    """Tests for TunnelType enum."""
+
+    def test_ngrok_value(self) -> None:
+        """Test ngrok tunnel type value."""
+        assert TunnelType.NGROK.value == "ngrok"
+
+    def test_tailscale_value(self) -> None:
+        """Test tailscale tunnel type value."""
+        assert TunnelType.TAILSCALE.value == "tailscale"
+
+    def test_from_string(self) -> None:
+        """Test creating TunnelType from string."""
+        assert TunnelType("ngrok") == TunnelType.NGROK
+        assert TunnelType("tailscale") == TunnelType.TAILSCALE
+
+
+# ============================================================================
+# NgrokTunnelManager Tests
+# ============================================================================
+
+
+class TestNgrokTunnelManagerInit:
+    """Tests for NgrokTunnelManager initialization."""
+
+    def test_default_initialization(self) -> None:
+        """Test default initialization."""
+        manager = NgrokTunnelManager()
+        assert manager.api_host == "localhost"
+        assert manager.api_port == 4040
+        assert manager.timeout == 10.0
+
+    def test_custom_initialization(self) -> None:
+        """Test custom initialization."""
+        manager = NgrokTunnelManager(
+            api_host="custom-host",
+            api_port=8080,
+            timeout=30.0,
+        )
+        assert manager.api_host == "custom-host"
+        assert manager.api_port == 8080
+        assert manager.timeout == 30.0
+
+    def test_api_url_property(self, ngrok_manager: NgrokTunnelManager) -> None:
+        """Test api_url property."""
+        assert ngrok_manager.api_url == "http://localhost:4040"
+
+
+class TestNgrokTunnelManagerAvailability:
+    """Tests for NgrokTunnelManager availability check."""
+
+    def test_is_available_when_installed(
+        self, ngrok_manager: NgrokTunnelManager
+    ) -> None:
+        """Test is_available returns True when ngrok is installed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert ngrok_manager.is_available() is True
+
+    def test_is_available_when_not_installed(
+        self, ngrok_manager: NgrokTunnelManager
+    ) -> None:
+        """Test is_available returns False when ngrok is not installed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            assert ngrok_manager.is_available() is False
+
+    def test_is_available_handles_exception(
+        self, ngrok_manager: NgrokTunnelManager
+    ) -> None:
+        """Test is_available handles exceptions gracefully."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert ngrok_manager.is_available() is False
+
+
+class TestNgrokTunnelManagerGetPublicUrl:
+    """Tests for NgrokTunnelManager.get_public_url."""
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_success(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+        ngrok_tunnels_response: dict,
+    ) -> None:
+        """Test successful URL retrieval."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = ngrok_tunnels_response
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            url = await ngrok_manager.get_public_url()
+            assert url == "https://abc123.ngrok.io"
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_prefers_https(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+    ) -> None:
+        """Test that HTTPS URL is preferred over HTTP."""
+        response_data = {
+            "tunnels": [
+                {
+                    "public_url": "http://http-only.ngrok.io",
+                    "proto": "http",
+                },
+                {
+                    "public_url": "https://https-first.ngrok.io",
+                    "proto": "https",
+                },
+            ]
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response_data
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            url = await ngrok_manager.get_public_url()
+            assert url == "https://https-first.ngrok.io"
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_no_tunnels(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+    ) -> None:
+        """Test error when no tunnels are found."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = {"tunnels": []}
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            with pytest.raises(TunnelAPIError, match="No ngrok tunnels found"):
+                await ngrok_manager.get_public_url()
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_connection_error(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+    ) -> None:
+        """Test error when ngrok API is not accessible."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+
+            with pytest.raises(
+                TunnelNotReadyError, match="Cannot connect to ngrok API"
+            ):
+                await ngrok_manager.get_public_url()
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_caches_result(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+        ngrok_tunnels_response: dict,
+    ) -> None:
+        """Test that URL is cached after first retrieval."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = ngrok_tunnels_response
+            mock_response.raise_for_status = MagicMock()
+
+            mock_get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__.return_value.get = mock_get
+
+            # First call
+            url1 = await ngrok_manager.get_public_url()
+            # Second call should use cache
+            url2 = await ngrok_manager.get_public_url()
+
+            assert url1 == url2
+            # API should only be called once
+            assert mock_get.call_count == 1
+
+
+class TestNgrokTunnelManagerWaitForReady:
+    """Tests for NgrokTunnelManager.wait_for_ready."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_ready_immediate(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+        ngrok_tunnels_response: dict,
+    ) -> None:
+        """Test wait_for_ready when tunnel is immediately ready."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = ngrok_tunnels_response
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            url = await ngrok_manager.wait_for_ready(max_attempts=5)
+            assert url == "https://abc123.ngrok.io"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_ready_retries(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+        ngrok_tunnels_response: dict,
+    ) -> None:
+        """Test wait_for_ready retries on failure."""
+        call_count = 0
+
+        async def mock_get(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise httpx.ConnectError("Not ready")
+            mock_response = MagicMock()
+            mock_response.json.return_value = ngrok_tunnels_response
+            mock_response.raise_for_status = MagicMock()
+            return mock_response
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = mock_get
+
+            url = await ngrok_manager.wait_for_ready(max_attempts=5, delay=0.01)
+            assert url == "https://abc123.ngrok.io"
+            assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_wait_for_ready_timeout(
+        self,
+        ngrok_manager: NgrokTunnelManager,
+    ) -> None:
+        """Test wait_for_ready raises after max attempts."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                side_effect=httpx.ConnectError("Not ready")
+            )
+
+            with pytest.raises(TunnelNotReadyError, match="not ready after"):
+                await ngrok_manager.wait_for_ready(max_attempts=2, delay=0.01)
+
+
+class TestNgrokTunnelManagerGetWebhookUrl:
+    """Tests for NgrokTunnelManager.get_webhook_url."""
+
+    def test_get_webhook_url_after_discovery(
+        self, ngrok_manager: NgrokTunnelManager
+    ) -> None:
+        """Test get_webhook_url after URL discovery."""
+        ngrok_manager._cached_url = "https://abc123.ngrok.io"
+
+        webhook_url = ngrok_manager.get_webhook_url()
+        assert webhook_url == "https://abc123.ngrok.io/webhooks/github"
+
+    def test_get_webhook_url_custom_path(
+        self, ngrok_manager: NgrokTunnelManager
+    ) -> None:
+        """Test get_webhook_url with custom path."""
+        ngrok_manager._cached_url = "https://abc123.ngrok.io"
+
+        webhook_url = ngrok_manager.get_webhook_url("/custom/webhook")
+        assert webhook_url == "https://abc123.ngrok.io/custom/webhook"
+
+    def test_get_webhook_url_before_discovery(
+        self, ngrok_manager: NgrokTunnelManager
+    ) -> None:
+        """Test get_webhook_url raises before URL discovery."""
+        with pytest.raises(RuntimeError, match="Must call get_public_url"):
+            ngrok_manager.get_webhook_url()
+
+
+# ============================================================================
+# TailscaleTunnelManager Tests
+# ============================================================================
+
+
+class TestTailscaleTunnelManagerAvailability:
+    """Tests for TailscaleTunnelManager availability check."""
+
+    def test_is_available_when_installed(
+        self, tailscale_manager: TailscaleTunnelManager
+    ) -> None:
+        """Test is_available returns True when tailscale is installed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert tailscale_manager.is_available() is True
+
+    def test_is_available_when_not_installed(
+        self, tailscale_manager: TailscaleTunnelManager
+    ) -> None:
+        """Test is_available returns False when tailscale is not installed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            assert tailscale_manager.is_available() is False
+
+
+class TestTailscaleTunnelManagerGetPublicUrl:
+    """Tests for TailscaleTunnelManager.get_public_url."""
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_success(
+        self,
+        tailscale_manager: TailscaleTunnelManager,
+        tailscale_status_response: dict,
+    ) -> None:
+        """Test successful URL retrieval."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps(tailscale_status_response),
+            )
+
+            url = await tailscale_manager.get_public_url()
+            assert url == "https://my-machine.tailnet123.ts.net"
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_command_failure(
+        self,
+        tailscale_manager: TailscaleTunnelManager,
+    ) -> None:
+        """Test error when tailscale command fails."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stderr="Tailscale not connected",
+            )
+
+            with pytest.raises(TunnelNotReadyError, match="Tailscale command failed"):
+                await tailscale_manager.get_public_url()
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_no_dns_name(
+        self,
+        tailscale_manager: TailscaleTunnelManager,
+    ) -> None:
+        """Test error when DNS name is not available."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=json.dumps({"Self": {}}),
+            )
+
+            with pytest.raises(
+                TunnelAPIError, match="Could not determine Tailscale DNS"
+            ):
+                await tailscale_manager.get_public_url()
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_timeout(
+        self,
+        tailscale_manager: TailscaleTunnelManager,
+    ) -> None:
+        """Test error when tailscale command times out."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(
+                cmd="tailscale status",
+                timeout=10,
+            )
+
+            with pytest.raises(TunnelNotReadyError, match="timed out"):
+                await tailscale_manager.get_public_url()
+
+    @pytest.mark.asyncio
+    async def test_get_public_url_invalid_json(
+        self,
+        tailscale_manager: TailscaleTunnelManager,
+    ) -> None:
+        """Test error when output is not valid JSON."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="not valid json",
+            )
+
+            with pytest.raises(TunnelAPIError, match="Failed to parse"):
+                await tailscale_manager.get_public_url()
+
+
+class TestTailscaleTunnelManagerIsFunnelEnabled:
+    """Tests for TailscaleTunnelManager.is_funnel_enabled."""
+
+    @pytest.mark.asyncio
+    async def test_is_funnel_enabled_true(
+        self, tailscale_manager: TailscaleTunnelManager
+    ) -> None:
+        """Test is_funnel_enabled returns True when enabled."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = await tailscale_manager.is_funnel_enabled()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_is_funnel_enabled_false(
+        self, tailscale_manager: TailscaleTunnelManager
+    ) -> None:
+        """Test is_funnel_enabled returns False when not enabled."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            result = await tailscale_manager.is_funnel_enabled()
+            assert result is False
+
+
+class TestTailscaleTunnelManagerGetWebhookUrl:
+    """Tests for TailscaleTunnelManager.get_webhook_url."""
+
+    def test_get_webhook_url_after_discovery(
+        self, tailscale_manager: TailscaleTunnelManager
+    ) -> None:
+        """Test get_webhook_url after URL discovery."""
+        tailscale_manager._cached_url = "https://my-machine.tailnet.ts.net"
+
+        webhook_url = tailscale_manager.get_webhook_url()
+        assert webhook_url == "https://my-machine.tailnet.ts.net/webhooks/github"
+
+
+# ============================================================================
+# Factory Function Tests
+# ============================================================================
+
+
+class TestGetTunnelManager:
+    """Tests for get_tunnel_manager factory function."""
+
+    def test_creates_ngrok_manager(self) -> None:
+        """Test factory creates NgrokTunnelManager."""
+        manager = get_tunnel_manager(TunnelType.NGROK)
+        assert isinstance(manager, NgrokTunnelManager)
+
+    def test_creates_tailscale_manager(self) -> None:
+        """Test factory creates TailscaleTunnelManager."""
+        manager = get_tunnel_manager(TunnelType.TAILSCALE)
+        assert isinstance(manager, TailscaleTunnelManager)
+
+    def test_passes_kwargs_to_ngrok(self) -> None:
+        """Test factory passes kwargs to NgrokTunnelManager."""
+        manager = get_tunnel_manager(
+            TunnelType.NGROK,
+            api_host="custom-host",
+            api_port=8080,
+        )
+        assert manager.api_host == "custom-host"
+        assert manager.api_port == 8080
+
+
+class TestGetTunnelTypeFromEnv:
+    """Tests for get_tunnel_type_from_env function."""
+
+    def test_default_is_ngrok(self) -> None:
+        """Test default tunnel type is ngrok."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = get_tunnel_type_from_env()
+            assert result == TunnelType.NGROK
+
+    def test_reads_from_environment(self) -> None:
+        """Test reading tunnel type from environment."""
+        with patch.dict(os.environ, {"TUNNEL_TYPE": "tailscale"}):
+            result = get_tunnel_type_from_env()
+            assert result == TunnelType.TAILSCALE
+
+    def test_handles_unknown_value(self) -> None:
+        """Test handling unknown tunnel type defaults to ngrok."""
+        with patch.dict(os.environ, {"TUNNEL_TYPE": "unknown"}):
+            result = get_tunnel_type_from_env()
+            assert result == TunnelType.NGROK
+
+
+class TestDiscoverTunnelUrl:
+    """Tests for discover_tunnel_url convenience function."""
+
+    @pytest.mark.asyncio
+    async def test_discovers_ngrok_url(
+        self,
+        ngrok_tunnels_response: dict,
+    ) -> None:
+        """Test discovering ngrok URL."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_response = MagicMock()
+            mock_response.json.return_value = ngrok_tunnels_response
+            mock_response.raise_for_status = MagicMock()
+
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            with patch.object(NgrokTunnelManager, "is_available", return_value=True):
+                url = await discover_tunnel_url(TunnelType.NGROK, wait=False)
+                assert url == "https://abc123.ngrok.io"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_not_available(self) -> None:
+        """Test raises error when tunnel is not available."""
+        with patch.object(NgrokTunnelManager, "is_available", return_value=False):
+            with pytest.raises(Exception, match="is not available"):
+                await discover_tunnel_url(TunnelType.NGROK, wait=False)
+
+    @pytest.mark.asyncio
+    async def test_uses_env_when_no_type_specified(
+        self,
+        ngrok_tunnels_response: dict,
+    ) -> None:
+        """Test uses environment variable when no type specified."""
+        with patch.dict(os.environ, {"TUNNEL_TYPE": "ngrok"}):
+            with patch("httpx.AsyncClient") as mock_client:
+                mock_response = MagicMock()
+                mock_response.json.return_value = ngrok_tunnels_response
+                mock_response.raise_for_status = MagicMock()
+
+                mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                    return_value=mock_response
+                )
+
+                with patch.object(
+                    NgrokTunnelManager, "is_available", return_value=True
+                ):
+                    url = await discover_tunnel_url(wait=False)
+                    assert url == "https://abc123.ngrok.io"
+
+
+# ============================================================================
+# Error Classes Tests
+# ============================================================================
+
+
+class TestErrorClasses:
+    """Tests for custom error classes."""
+
+    def test_tunnel_error_is_exception(self) -> None:
+        """Test TunnelError is an Exception."""
+        assert issubclass(TunnelError, Exception)
+
+    def test_tunnel_not_ready_error_is_tunnel_error(self) -> None:
+        """Test TunnelNotReadyError is a TunnelError."""
+        assert issubclass(TunnelNotReadyError, TunnelError)
+
+    def test_tunnel_api_error_is_tunnel_error(self) -> None:
+        """Test TunnelAPIError is a TunnelError."""
+        assert issubclass(TunnelAPIError, TunnelError)
+
+    def test_errors_can_be_raised(self) -> None:
+        """Test errors can be raised with messages."""
+        with pytest.raises(TunnelError, match="test message"):
+            raise TunnelError("test message")
+
+        with pytest.raises(TunnelNotReadyError, match="not ready"):
+            raise TunnelNotReadyError("not ready")
+
+        with pytest.raises(TunnelAPIError, match="api error"):
+            raise TunnelAPIError("api error")


### PR DESCRIPTION
Implements Epic #42 - Local-to-Cloud Tunneling for the Notifier service.

Stories:
- Story 3.1: Development Launcher Script (start_dev_notifier.sh)
- Story 3.2: Tunnel URL Discovery (tunnel_manager.py)
- Story 3.3: GitHub Webhook URL Configuration (Bonus)
- Story 3.4: Development Documentation (local-development.md)

Tests: 44 unit tests for tunnel manager
All acceptance criteria met.

Closes #42